### PR TITLE
Canary pipelines and entrypoints

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,12 @@ classifiers = [
   "Typing :: Typed",
 ]
 dynamic = ["version"]
-dependencies = []
+dependencies = [
+  "click >=8.1",
+  "numpy >=1.26",
+  "dipy >=1.9",
+  "HD_BET @ git+https://github.com/MIC-DKFZ/HD-BET@ae16068",
+]
 
 [project.optional-dependencies]
 test = [
@@ -55,6 +60,8 @@ Homepage = "https://github.com/brain-microstructure-exploration-tools/abcd-micro
 Discussions = "https://github.com/brain-microstructure-exploration-tools/abcd-microstructure-pipelines/discussions"
 Changelog = "https://github.com/brain-microstructure-exploration-tools/abcd-microstructure-pipelines/releases"
 
+[project.scripts]
+gen_masks = "abcd_microstructure_pipelines.masks:gen_masks"
 
 [tool.setuptools_scm]
 write_to = "src/abcd_microstructure_pipelines/_version.py"

--- a/src/abcd_microstructure_pipelines/masks.py
+++ b/src/abcd_microstructure_pipelines/masks.py
@@ -1,0 +1,68 @@
+import logging
+import os
+from pathlib import Path
+
+import click
+import dipy.core.gradients
+import dipy.io
+import dipy.io.image
+
+logging.basicConfig(level=os.environ.get("LOG_LEVEL", "WARN"))
+
+
+def find_all_cases(root: Path):
+    for dwi in root.rglob("*_dwi.nii.gz"):
+        yield dwi.with_name(dwi.name.removesuffix(".nii.gz"))
+
+
+def gen_b0_mean(dwi: Path, bval: Path, bvec: Path, b0_out: Path):
+    data, affine, img = dipy.io.image.load_nifti(str(dwi), return_img=True)
+    bvals, bvecs = dipy.io.read_bvals_bvecs(str(bval), str(bvec))
+
+    gtab = dipy.core.gradients.gradient_table(bvals, bvecs)
+    b0_mean = data[:, :, :, gtab.b0s_mask].mean(axis=3)
+
+    b0_out.parent.mkdir(parents=True, exist_ok=True)
+
+    logging.debug(f"{b0_out}")
+    dipy.io.image.save_nifti(str(b0_out), b0_mean, affine, img.header)
+
+
+@click.command("gen_masks")
+@click.option("--inputs", "-i", required=True, type=Path)
+@click.option("--outputs", "-o", required=True, type=Path)
+@click.option("--overwrite", is_flag=True)
+def gen_masks(inputs: Path, outputs: Path, overwrite: bool):
+    b0_tasks = []
+    hd_bet_input = []
+    hd_bet_output = []
+
+    for base in find_all_cases(inputs):
+        base_out = outputs.joinpath(base.relative_to(inputs))
+
+        dwi = base.with_suffix(".nii.gz")
+        bval = base.with_suffix(".bval")
+        bvec = base.with_suffix(".bvec")
+
+        b0_out = base_out.with_suffix(".b0.nii.gz")
+
+        if overwrite or not b0_out.exists():
+            b0_tasks.append((dwi, bval, bvec, b0_out))
+
+        # HD_BET will rename this to "_mask.nii.gz"
+        mask_out = base_out.with_suffix(".nii.gz")
+        mask_out_real = base_out.with_name(base_out.name + "_mask.nii.gz")
+
+        if overwrite or not mask_out_real.exists():
+            hd_bet_input.append(str(b0_out))
+            hd_bet_output.append(str(mask_out))
+
+    logging.debug("Generate missing b0_mean")
+    for dwi, bval, bvec, mask_out in b0_tasks:
+        gen_b0_mean(dwi, bval, bvec, mask_out)
+
+    logging.debug("Generate missing masks")
+    # don't import till now since it takes time to initialize.
+    import HD_BET.run
+
+    HD_BET.run.run_hd_bet(hd_bet_input, hd_bet_output, overwrite=overwrite)


### PR DESCRIPTION
There is something to think about here in that HD_BET has significant setup overhead, so we want to run all HD_BET tasks in one batch, and since each task is resource intensive we don't want (much) parallelism in those tasks.

The b0 tasks would parallelize very well with `multiprocessing.Pool`.

The b0 results are not used by anything other than the hd_bet task.

---

So with all that in mind, I decided to set the API as "create masks", generating b0 results as an implementation detail. Opt-in parallelism via `multiprocessing.Pool` is then an easy win, and HD_BET has its own runner.

I don't like that there's explicit control over b0 task parellism/overwrite, but HD_BET has its own controls for this. I don't think there's a great solution here since the HD_BET runner is slow to start and not very modular.

Translating these to Pydra is the next step, but I think we'll have the same issues there.