### PR TITLE
add pre-commit to dev dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ test = [
 dev = [
   "pytest >=6",
   "pytest-cov >=3",
+  "pre-commit",
 ]
 docs = [
   "sphinx>=7.0",


### PR DESCRIPTION
this is because it's handy to run pre-commit locally

if you do `pre-commit install` then it will just become a git precommit hook