### PR TITLE
19 write a unit test for gen masks stuff

### DIFF
--- a/tests/test_masks.py
+++ b/tests/test_masks.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from abcd_microstructure_pipelines.masks import compute_b0_mean
+
+
+@pytest.fixture()
+def dwi_data_small_random():
+    rng = np.random.default_rng(1337)
+    dwi_data = rng.random(size=(3, 4, 5, 6))
+    bvals = [0, 1000, 500, 0, 0, 500]
+    bvecs = rng.random(size=(6, 3))
+    bvecs = bvecs / np.sqrt((bvecs**2).sum(axis=1, keepdims=True))
+    return dwi_data, bvals, bvecs
+
+
+def test_compute_b0_mean(dwi_data_small_random):
+    dwi_data, bvals, bvecs = dwi_data_small_random
+    b0_mean = compute_b0_mean(dwi_data, bvals, bvecs)
+    assert b0_mean == pytest.approx(
+        (dwi_data[..., 0] + dwi_data[..., 3] + dwi_data[..., 4]) / 3
+    )


### PR DESCRIPTION
Close #19 

Just want to start the habit of unit testing and set a precedent.

For the b0 mean I separated out the trivial computation from the IO step because that's [a good pattern](https://learn.scientific-python.org/development/principles/design/#keep-io-separate) and also because it gives me something to unit test.

Some IO things are hard to separate though. Like HD-BET is going to do its own thing and it ultimately operates on files and not arrays (right? if that's not the case and it's possible to make it operate on arrays then we should do that...)

And I haven't thought of a good way to unit test the actual IO steps.
@allemangD any thoughts on that? Now that `compute_b0_mean` is tested, how would you approach the problem of testing `gen_b0_mean`? Mocking? Having some small actual data files to run on?