### PR TITLE
Fix apidocs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,7 @@ instance/
 
 # Sphinx documentation
 docs/_build/
+docs/*.rst
 
 # PyBuilder
 .pybuilder/

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,6 +7,10 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.11"
+  jobs:
+    pre_build:
+      - sphinx-apidoc -o docs/ src/ --separate --module-first -d 2
+
 sphinx:
   configuration: docs/conf.py
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -95,11 +95,13 @@ def build_api_docs(session: nox.Session) -> None:
     session.run(
         "sphinx-apidoc",
         "-o",
-        "api/",
+        ".",
+        "--separate",
         "--module-first",
-        "--no-toc",
+        "-d",
+        "2",
         "--force",
-        "../src/abcdmicro",
+        "../src",
     )
 
 


### PR DESCRIPTION
`sphinx-apidoc` is generating an empty docs for `abcdmicro.run`, even though it has `gen_masks()` click entrypoint with a docstring. I guess somehow the click decorators clobber the docstring and it won't work. I figure this is probably a good place to put documentation about the entrypoint CLIs themselves but I'm not yet sure how to do this.

I also looked into filtering out `abcdmicro.run` from the apidocs entirely. The easiest way to do this is to rename it to `_run` to mark it private, but then the wrapper script in SlicerBrainMicrostructure is accessing a private member. You can also explicitly list it in the arguments to `sphinx-apidoc` in `.readthedocs.yml`... this might be our best option if we want to do it.
