### PR TITLE
ci: fix macos python version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,12 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.9", "3.12"]
-        runs-on: [ubuntu-latest, macos-latest, windows-latest]
+        runs-on: [ubuntu-latest, windows-latest]
+        include:
+          - runs-on: macos-latest
+            python-version: "3.10"
+          - runs-on: macos-latest
+            python-version: "3.12"
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
The macos python3.9 CI failure is due to [this](https://github.com/actions/setup-python/issues/850). We chose `macos-latest` [here](https://github.com/brain-microstructure-exploration-tools/abcd-microstructure-pipelines/blob/35ae56d29d0b6fbf1b5b7d2631f4589504a0387f/.github/workflows/ci.yml#L44C34-L44C46) and it seems that that `macos-latest` has changed such that it now points to `macos-14-arm64`. Python 3.9 isn't supported by the setup-python action on the platform `macos-14-arm64`.