### PR TITLE
COMP: Use pinned version on HD-BET fork

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
   "click >=8.1",
   "numpy >=1.26",
   "dipy >=1.9",
-  "HD_BET @ git+https://github.com/MIC-DKFZ/HD-BET@ae16068",
+  "HD_BET @ https://github.com/brain-microstructure-exploration-tools/HD-BET/archive/refs/tags/v1.0.0.zip#sha256=d48908854207b839552f2059c9cf2a48819b847bc1eb0ea4445d1d589471a1f5",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Using `zip` archive and hash allows pip to cache the distribution, and allows installation if `git` is unavailable for some reason.

I'm not sure of a way to allow version resolution here. I think for that the package must published on pypi or some private index. It seems bad etiquette to publish the package from the fork so I wouldn't do that, certainly not on the `HD-BET` name. Maybe we use a name that clearly indicates it is a fork and _not_ upstream? I'm not sure what best practice is but it's probably not reasonable to ask the current maintainer to overhaul their distribution just for our integration to Slicer. It is Apache license so we are _allowed_ to distribute, but I don't want to sit on the name. Installing from the GitHub archive should work well enough for now.

https://github.com/brain-microstructure-exploration-tools/HD-BET

I did create [a tag v1.0.0](https://github.com/brain-microstructure-exploration-tools/HD-BET/releases/tag/v1.0.0) of upstream at the time of fork.