### PR TITLE
Relax warning ignore to cover more cases

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,9 +88,9 @@ addopts = ["-ra", "--showlocals", "--strict-markers", "--strict-config"]
 xfail_strict = true
 filterwarnings = [
   "error",
-  "ignore:pkg_resources is deprecated as an API:UserWarning", # accommodating AMICO till it is updated
-  "ignore:Deprecated call to `pkg_resources:DeprecationWarning", # accommodating AMICO till it is updated
-  "ignore:.*legacy descoteaux07 SH basis.*:PendingDeprecationWarning", # accommodating AMICO till it is updated
+  "ignore:pkg_resources is deprecated as an API", # accommodating AMICO till it is updated (matches both UserWarning and DeprecationWarning)
+  "ignore:Deprecated call to `pkg_resources", # accommodating AMICO till it is updated (matches both UserWarning and DeprecationWarning)
+  "ignore:.*legacy descoteaux07 SH basis.*:PendingDeprecationWarning",
 ]
 log_cli_level = "INFO"
 testpaths = [


### PR DESCRIPTION
Without this we were getting a CI failure on python3.10 ubuntu runner only.

Hopefully the CI passes