### PR TITLE
Use a more general format for defining response functions

### DIFF
--- a/src/abcdmicro/csd.py
+++ b/src/abcdmicro/csd.py
@@ -90,7 +90,7 @@ def estimate_response_function(
             "Ratio of response diffusion tensor eigenvalues is greater than 0.3. For a response function we expect more prolateness. Something may be wrong."
         )
 
-    return InMemoryResponseFunctionResource.estimate_from_prolate_tensor(
+    return InMemoryResponseFunctionResource.from_prolate_tensor(
         response, gtab=gtab_low_b, sh_order_max=sh_order_max
     )
 

--- a/src/abcdmicro/io.py
+++ b/src/abcdmicro/io.py
@@ -140,13 +140,13 @@ class FslBvecResource(BvecResource):
 
 
 @dataclass
-class TextResponseFunctionResource(ResponseFunctionResource):
-    """A response function that is saved to disk in a text file."""
+class JsonResponseFunctionResource(ResponseFunctionResource):
+    """A response function that is saved to disk in a json file."""
 
     is_loaded: ClassVar[bool] = False
 
     path_in: InitVar[PathLike]
-    """Path to the underlying text file"""
+    """Path to the underlying json file"""
 
     path: Path = field(init=False)
 
@@ -173,17 +173,17 @@ class TextResponseFunctionResource(ResponseFunctionResource):
     @staticmethod
     def save(
         response: ResponseFunctionResource, path: PathLike
-    ) -> TextResponseFunctionResource:
-        """Save response function data to a path, creating a TextResponseFunctionResource."""
+    ) -> JsonResponseFunctionResource:
+        """Save response function data to a path, creating a JsonResponseFunctionResource."""
         path = normalize_path(path)
         with path.open("w", encoding="utf-8") as file:
             json.dump(
                 [
-                    [eval.item() for eval in response.get()[0]],
+                    [coeff.item() for coeff in response.get()[0]],
                     response.get()[
                         1
                     ].item(),  # json won't serialize numpy float type, it has to be native python float, hence ".item()"
                 ],
                 file,
             )
-        return TextResponseFunctionResource(path)
+        return JsonResponseFunctionResource(path)

--- a/tests/test_csd.py
+++ b/tests/test_csd.py
@@ -104,7 +104,7 @@ def test_csd_peaks(
     mock_res_mask = mock_response_from_mask(mocker)
     mock_compute_mask = mock_mask_for_response(mocker, dwi_data_small_random)
     mock_estimate_response = mocker.patch(
-        "abcdmicro.csd.InMemoryResponseFunctionResource.estimate_from_prolate_tensor",
+        "abcdmicro.csd.InMemoryResponseFunctionResource.from_prolate_tensor",
         return_value=response_function,
     )
 
@@ -183,7 +183,7 @@ def test_compute_csd_fods(
     mock_res_mask = mock_response_from_mask(mocker)
     mock_compute_mask = mock_mask_for_response(mocker, dwi_data_small_random)
     mock_estimate_response = mocker.patch(
-        "abcdmicro.csd.InMemoryResponseFunctionResource.estimate_from_prolate_tensor",
+        "abcdmicro.csd.InMemoryResponseFunctionResource.from_prolate_tensor",
         return_value=response_function,
     )
 

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -11,8 +11,8 @@ from scipy.linalg import expm
 from abcdmicro.io import (
     FslBvalResource,
     FslBvecResource,
+    JsonResponseFunctionResource,
     NiftiVolumeResource,
-    TextResponseFunctionResource,
 )
 from abcdmicro.resource import (
     InMemoryBvalResource,
@@ -120,8 +120,8 @@ def test_text_response_function_resource_save_load(response_function, tmp_path):
         sh_coeffs=response_function[0], avg_signal=response_function[1]
     )
 
-    path = tmp_path / "test_response.txt"
-    res_disk = TextResponseFunctionResource.save(response, path)
+    path = tmp_path / "test_response.json"
+    res_disk = JsonResponseFunctionResource.save(response, path)
     res_mem2 = res_disk.load()
 
     assert len(res_mem2.get()) == 2

--- a/tests/test_resource.py
+++ b/tests/test_resource.py
@@ -163,7 +163,7 @@ def test_response_inmemory_get(prolate_response_function):
 def test_dipy_conversion(
     prolate_response_function, dipy_gradient_table, dipy_response_object
 ):
-    res = InMemoryResponseFunctionResource.estimate_from_prolate_tensor(
+    res = InMemoryResponseFunctionResource.from_prolate_tensor(
         response=prolate_response_function, gtab=dipy_gradient_table
     )
     res_dipy = res.get_dipy_object()

--- a/tests/test_tractseg.py
+++ b/tests/test_tractseg.py
@@ -50,8 +50,13 @@ def response_function() -> InMemoryResponseFunctionResource:
     return InMemoryResponseFunctionResource(sh_coeffs=sh_coeffs, avg_signal=avg_signal)
 
 
-@pytest.mark.parametrize("response", [None, response_function])
-def test_tractseg(mocker, dwi_data_small_random, response):
+@pytest.mark.parametrize("response_is_none", [True, False])
+def test_tractseg(
+    mocker,
+    dwi_data_small_random,
+    response_function,
+    response_is_none,
+):
     # Create mock csd peaks data
     rng = np.random.default_rng(17)
     vol = dwi_data_small_random.volume
@@ -74,6 +79,8 @@ def test_tractseg(mocker, dwi_data_small_random, response):
     mocker_run_tract_seg = mocker.patch(
         "abcdmicro.tractseg.run_tractseg", return_value=mock_tractseg_output
     )
+
+    response = None if response_is_none else response_function
 
     mock_mask = mocker.Mock()
     seg_volume = extract_tractseg(


### PR DESCRIPTION
Addresses #103 

- [x] Modify the ResponseFunctionResource. to store the response function data as sh_coeffs
- [x] If using a function that outputs the tuple format i.e. response_from_mask_sst, we should automatically convert to the sh_coeffs and store the result.
- [x] Include a function to return the data as AxSymShResponseObject so that is recognized by DIPY i.e. response.get_dipy_object()? 
- [x] Add unit tests for tractseg and CSD computation
- [x] Add a test to confirm the conversion to and from the different response formats. 
- [x] Add functions to save and load response functions from text file. 

Currenty, the response function estimate assumes ssst (single shell, single tissue)
- Do we want to also support msmt
- If adding msmt, would need to be able to convert to MultiShellResponse object. 
- **TODO:** Add a function for combining response functions (averaging) - for group analyses.