### PR TITLE
Add downsampling to demo notebooks

### DIFF
--- a/notebooks/example-group-template.py
+++ b/notebooks/example-group-template.py
@@ -1,6 +1,7 @@
 # ---
 # jupyter:
 #   jupytext:
+#     formats: ipynb,py:percent
 #     text_representation:
 #       extension: .py
 #       format_name: percent
@@ -25,6 +26,15 @@
 # 2. Build a single-metric population template
 # 3. Build a multi-metric population template
 # 4. Save templates to disk
+
+# %% [markdown]
+# ### Spatial subsampling
+#
+# Configure the following to spatially subsample the data and run through the demo more quickly at lower spatial resolution.
+
+# %%
+SUBSAMPLE = True
+SUBSAMPLE_FACTOR = 2
 
 # %% [markdown]
 # ## 0. Download example data
@@ -100,6 +110,12 @@ for subject in SUBJECTS:
     ).load())
 
 print(f"Loaded {len(dwis)} subjects")
+
+if SUBSAMPLE:
+    from kwneuro.dwi import subsample_dwi
+
+    dwis = [subsample_dwi(d, SUBSAMPLE_FACTOR) for d in dwis]
+    print(f"Subsampled by factor {SUBSAMPLE_FACTOR}")
 
 # Brain extraction in one batch (HD-BET initializes once)
 with tempfile.TemporaryDirectory() as tmpdir:

--- a/notebooks/example-group-template.py
+++ b/notebooks/example-group-template.py
@@ -47,17 +47,9 @@ SUBSAMPLE_FACTOR = 2
 # Total download size: ~250 MB for 3 subjects.
 
 # %%
-import subprocess
-import sys
 from pathlib import Path
 
-# Install openneuro-py if needed
-try:
-    import openneuro as on
-except ImportError:
-    print("Installing openneuro-py...")
-    subprocess.check_call([sys.executable, "-m", "pip", "install", "-q", "openneuro-py"])
-    import openneuro as on
+import openneuro as on
 
 # %%
 DATA_DIR = Path("example_data/ds000221")

--- a/notebooks/example-pipeline.py
+++ b/notebooks/example-pipeline.py
@@ -1,6 +1,7 @@
 # ---
 # jupyter:
 #   jupytext:
+#     formats: ipynb,py:percent
 #     text_representation:
 #       extension: .py
 #       format_name: percent
@@ -29,6 +30,15 @@
 # 6. CSD / Fiber Orientation Distributions
 # 7. TractSeg white matter tract segmentation
 # 8. Saving results to disk
+
+# %% [markdown]
+# ### Spatial subsampling
+#
+# Configure the following to spatially subsample the data and run through the demo more quickly at lower spatial resolution.
+
+# %%
+SUBSAMPLE = True
+SUBSAMPLE_FACTOR = 2
 
 # %% [markdown]
 # ## 0. Download example data
@@ -72,6 +82,12 @@ dwi = Dwi(
     FslBvalResource(data_dir / f"{basename}.bval"),
     FslBvecResource(data_dir / f"{basename}.bvec"),
 ).load()
+
+if SUBSAMPLE:
+    from kwneuro.dwi import subsample_dwi
+
+    dwi = subsample_dwi(dwi, SUBSAMPLE_FACTOR)
+    print(f"Subsampled by factor {SUBSAMPLE_FACTOR}")
 
 vol = dwi.volume.get_array()
 bvals = dwi.bval.get()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,7 @@ notebooks = [
   "ipykernel",
   "notebook",
   "ipywidgets",
+  "openneuro-py",
 ]
 docs = [
   "sphinx>=7.0",

--- a/src/kwneuro/dwi.py
+++ b/src/kwneuro/dwi.py
@@ -25,6 +25,7 @@ from kwneuro.util import (
     PathLike,
     deep_equal_allclose,
     normalize_path,
+    subsample_volume,
     update_volume_metadata,
 )
 
@@ -230,3 +231,16 @@ class Dwi:
     ) -> Noddi:
         """Estimate NODDI model parameters from this DWI. See :meth:`kwneuro.noddi.Noddi.estimate_from_dwi` for details."""
         return Noddi.estimate_from_dwi(self, mask, dpar, n_kernel_dirs)
+
+
+def subsample_dwi(dwi: Dwi, factor: int = 2) -> Dwi:
+    """Spatially subsample a DWI by taking every Nth voxel along each spatial axis.
+
+    Convenience wrapper around :func:`kwneuro.util.subsample_volume` that returns a new
+    Dwi with the subsampled volume and the original b-values and b-vectors.
+    """
+    return Dwi(
+        volume=subsample_volume(dwi.volume, factor),
+        bval=dwi.bval,
+        bvec=dwi.bvec,
+    )

--- a/src/kwneuro/util.py
+++ b/src/kwneuro/util.py
@@ -61,6 +61,41 @@ def update_volume_metadata(
     return dict(header)
 
 
+def subsample_volume(volume: VolumeResource, factor: int = 2) -> InMemoryVolumeResource:
+    """Spatially subsample a volume by taking every Nth voxel along each spatial axis.
+
+    This is stride-based subsampling (not interpolated resampling).  It is mainly
+    useful for quickly reducing resolution in demo notebooks so that expensive
+    downstream steps run faster.
+
+    Args:
+        volume: The volume to subsample.
+        factor: Take every *factor*-th voxel along each of the first three
+            (spatial) dimensions.  Extra dimensions are left untouched.
+
+    Returns:
+        A new InMemoryVolumeResource with the subsampled data and an
+        updated affine that reflects the coarser voxel grid.
+    """
+    loaded = volume.load()
+    arr = loaded.get_array()
+    affine = loaded.get_affine()
+
+    slices: tuple[slice, ...] = (slice(None, None, factor),) * 3
+    if arr.ndim > 3:
+        slices = slices + (slice(None),) * (arr.ndim - 3)
+    new_arr = arr[slices]
+
+    new_affine = affine.copy()
+    new_affine[:3, :3] *= factor
+
+    return InMemoryVolumeResource(
+        array=new_arr,
+        affine=new_affine,
+        metadata=update_volume_metadata(loaded.get_metadata(), new_arr),
+    )
+
+
 def deep_equal_allclose(obj1: Any, obj2: Any) -> bool:
     """
     Recursively compares two objects, including nested lists, tuples,

--- a/tests/test_subsample.py
+++ b/tests/test_subsample.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from kwneuro.dwi import Dwi, subsample_dwi
+from kwneuro.resource import (
+    InMemoryBvalResource,
+    InMemoryBvecResource,
+    InMemoryVolumeResource,
+)
+from kwneuro.util import subsample_volume
+
+
+@pytest.fixture
+def affine_2mm():
+    """A simple diagonal affine with 2 mm voxel spacing."""
+    aff = np.eye(4)
+    np.fill_diagonal(aff[:3, :3], 2.0)
+    return aff
+
+
+@pytest.fixture
+def volume_3d(affine_2mm):
+    arr = np.arange(12 * 14 * 10, dtype=np.float64).reshape(12, 14, 10)
+    return InMemoryVolumeResource(array=arr, affine=affine_2mm, metadata={})
+
+
+@pytest.fixture
+def volume_4d(affine_2mm):
+    arr = np.arange(12 * 14 * 10 * 3, dtype=np.float64).reshape(12, 14, 10, 3)
+    return InMemoryVolumeResource(array=arr, affine=affine_2mm, metadata={})
+
+
+class TestSubsampleVolume:
+    def test_3d_shape(self, volume_3d):
+        result = subsample_volume(volume_3d, factor=2)
+        assert result.get_array().shape == (6, 7, 5)
+
+    def test_4d_shape(self, volume_4d):
+        result = subsample_volume(volume_4d, factor=2)
+        assert result.get_array().shape == (6, 7, 5, 3)
+
+    def test_4d_extra_dim_untouched(self, volume_4d):
+        result = subsample_volume(volume_4d, factor=2)
+        original = volume_4d.get_array()
+        # Every output voxel should match the strided input voxel
+        np.testing.assert_array_equal(
+            result.get_array()[1, 2, 3, :],
+            original[2, 4, 6, :],
+        )
+
+    def test_values_are_exact_subset(self, volume_3d):
+        result = subsample_volume(volume_3d, factor=2)
+        original = volume_3d.get_array()
+        np.testing.assert_array_equal(
+            result.get_array(),
+            original[::2, ::2, ::2],
+        )
+
+    def test_affine_scaling(self, volume_3d, affine_2mm):
+        result = subsample_volume(volume_3d, factor=3)
+        expected_affine = affine_2mm.copy()
+        expected_affine[:3, :3] *= 3
+        np.testing.assert_array_equal(result.get_affine(), expected_affine)
+
+    def test_affine_preserves_origin(self, volume_3d, affine_2mm):
+        affine_2mm[:3, 3] = [10.0, 20.0, 30.0]
+        vol = InMemoryVolumeResource(
+            array=volume_3d.get_array(), affine=affine_2mm, metadata={}
+        )
+        result = subsample_volume(vol, factor=2)
+        np.testing.assert_array_equal(result.get_affine()[:3, 3], [10.0, 20.0, 30.0])
+
+    def test_world_coords_preserved(self, volume_3d):
+        """World coordinate at output voxel (i,j,k) should equal world coordinate
+        at input voxel (i*f, j*f, k*f)."""
+        factor = 2
+        result = subsample_volume(volume_3d, factor=factor)
+        orig_affine = volume_3d.get_affine()
+        new_affine = result.get_affine()
+        # Check a few voxel indices
+        for idx in [(0, 0, 0), (1, 2, 3), (3, 5, 2)]:
+            orig_world = orig_affine @ np.array([i * factor for i in idx] + [1])
+            new_world = new_affine @ np.array([*list(idx), 1])
+            np.testing.assert_allclose(new_world, orig_world)
+
+    def test_factor_1_is_identity(self, volume_3d):
+        result = subsample_volume(volume_3d, factor=1)
+        np.testing.assert_array_equal(result.get_array(), volume_3d.get_array())
+        np.testing.assert_array_equal(result.get_affine(), volume_3d.get_affine())
+
+    def test_factor_3(self, volume_3d):
+        result = subsample_volume(volume_3d, factor=3)
+        assert result.get_array().shape == (4, 5, 4)
+
+
+class TestSubsampleDwi:
+    @pytest.fixture
+    def dwi(self, volume_4d):
+        n_dirs = volume_4d.get_array().shape[3]
+        bvals = np.array([0.0, 1000.0, 1000.0])[:n_dirs]
+        # Unit vectors for non-zero b-values
+        bvecs = np.zeros((n_dirs, 3))
+        for i in range(n_dirs):
+            if bvals[i] > 0:
+                bvecs[i] = [1.0, 0.0, 0.0]
+        return Dwi(
+            volume=volume_4d,
+            bval=InMemoryBvalResource(bvals),
+            bvec=InMemoryBvecResource(bvecs),
+        )
+
+    def test_returns_dwi(self, dwi):
+        result = subsample_dwi(dwi, factor=2)
+        assert isinstance(result, Dwi)
+
+    def test_volume_subsampled(self, dwi):
+        result = subsample_dwi(dwi, factor=2)
+        assert result.volume.get_array().shape == (6, 7, 5, 3)
+
+    def test_bval_preserved(self, dwi):
+        result = subsample_dwi(dwi, factor=2)
+        np.testing.assert_array_equal(result.bval.get(), dwi.bval.get())
+
+    def test_bvec_preserved(self, dwi):
+        result = subsample_dwi(dwi, factor=2)
+        np.testing.assert_array_equal(result.bvec.get(), dwi.bvec.get())

--- a/uv.lock
+++ b/uv.lock
@@ -44,6 +44,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c2/65/c61fc19a1b10d2367c00bd52a5585b89ce8fb408d2a18e41e9c14fe6510c/acvl_utils-0.2.5.tar.gz", hash = "sha256:062eebc28b83756cc8dbe7aa0a09f98a2f9ea8d20a16d2c11c8598d7d2b47102", size = 29138, upload-time = "2025-02-26T14:12:53.184Z" }
 
 [[package]]
+name = "aiofiles"
+version = "25.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/41/c3/534eac40372d8ee36ef40df62ec129bee4fdb5ad9706e58a29be53b2c970/aiofiles-25.1.0.tar.gz", hash = "sha256:a8d728f0a29de45dc521f18f07297428d56992a742f0cd2701ba86e44d23d5b2", size = 46354, upload-time = "2025-10-09T20:51:04.358Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/8a/340a1555ae33d7354dbca4faa54948d76d89a27ceef032c8c3bc661d003e/aiofiles-25.1.0-py3-none-any.whl", hash = "sha256:abe311e527c862958650f9438e859c1fa7568a141b22abcd015e120e86a85695", size = 14668, upload-time = "2025-10-09T20:51:03.174Z" },
+]
+
+[[package]]
 name = "aiohappyeyeballs"
 version = "2.6.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1822,6 +1831,15 @@ wheels = [
 ]
 
 [[package]]
+name = "graphql-core"
+version = "3.2.8"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/68/c5/36aa96205c3ecbb3d34c7c24189e4553c7ca2ebc7e1dd07432339b980272/graphql_core-3.2.8.tar.gz", hash = "sha256:015457da5d996c924ddf57a43f4e959b0b94fb695b85ed4c29446e508ed65cf3", size = 513181, upload-time = "2026-03-05T19:55:37.332Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/86/41/cb887d9afc5dabd78feefe6ccbaf83ff423c206a7a1b7aeeac05120b2125/graphql_core-3.2.8-py3-none-any.whl", hash = "sha256:cbee07bee1b3ed5e531723685369039f32ff815ef60166686e0162f540f1520c", size = 207349, upload-time = "2026-03-05T19:55:35.911Z" },
+]
+
+[[package]]
 name = "graphviz"
 version = "0.21"
 source = { registry = "https://pypi.org/simple" }
@@ -2743,6 +2761,7 @@ notebooks = [
     { name = "jupytext" },
     { name = "matplotlib" },
     { name = "notebook" },
+    { name = "openneuro-py" },
 ]
 test = [
     { name = "neurocombat" },
@@ -2774,6 +2793,7 @@ requires-dist = [
     { name = "neurocombat", marker = "extra == 'combat'", specifier = "==0.2.12" },
     { name = "notebook", marker = "extra == 'notebooks'" },
     { name = "numpy", specifier = "<2.4" },
+    { name = "openneuro-py", marker = "extra == 'notebooks'" },
     { name = "pandas" },
     { name = "pre-commit", marker = "extra == 'dev'" },
     { name = "pylint", marker = "extra == 'dev'" },
@@ -3977,6 +3997,25 @@ source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/f3/d86c845465a2723ad7e1e5c36dcd75ddb82898b3f53be47ebd429fb2fa5d/nvidia_nvtx-13.0.85-py3-none-manylinux1_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:4936d1d6780fbe68db454f5e72a42ff64d1fd6397df9f363ae786930fd5c1cd4", size = 148047, upload-time = "2025-09-04T08:29:01.761Z" },
     { url = "https://files.pythonhosted.org/packages/a8/64/3708a90d1ebe202ffdeb7185f878a3c84d15c2b2c31858da2ce0583e2def/nvidia_nvtx-13.0.85-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cb7780edb6b14107373c835bf8b72e7a178bac7367e23da7acb108f973f157a6", size = 148878, upload-time = "2025-09-04T08:28:53.627Z" },
+]
+
+[[package]]
+name = "openneuro-py"
+version = "2026.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiofiles" },
+    { name = "httpx" },
+    { name = "platformdirs" },
+    { name = "requests" },
+    { name = "sgqlc" },
+    { name = "tqdm" },
+    { name = "truststore" },
+    { name = "typer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e1/ff/01ad59f3035c5f5c68c719b570d811965f9eea2f24326c31bb542c5f6315/openneuro_py-2026.3.1.tar.gz", hash = "sha256:f258d9aff7ebe9229b090f10434e9f1a60921758d874efb9af3caac0606011e5", size = 305138, upload-time = "2026-03-27T22:49:54.963Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/f8/0788f743cd1136756b7b371575f7934f0e3c7b59e2c8c892fce891d23b49/openneuro_py-2026.3.1-py3-none-any.whl", hash = "sha256:2fcd0994368bcb5ef9c672e95b2f1bc573dcccdcd136d6c6deba145b0aa4b31c", size = 41183, upload-time = "2026-03-27T22:49:56.007Z" },
 ]
 
 [[package]]
@@ -5392,6 +5431,18 @@ wheels = [
 ]
 
 [[package]]
+name = "sgqlc"
+version = "18"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "graphql-core" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/13/60/3b8c93b3d5df873bd13bc8fe0a4021d5f7442ca7ee6b98c5152dd55e18c7/sgqlc-18.tar.gz", hash = "sha256:a09f76fb69a2760523144f8d3acbf06a1b3710f63bf87fbac142d3538b1d639b", size = 245818, upload-time = "2026-02-06T19:56:23.957Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/96/8a5b972de8ede610aa088360927411b05c50ebcd669e52b0a3bfd1ed3ed9/sgqlc-18-py3-none-any.whl", hash = "sha256:7af53b5c1aab4602a98a36d6d32bd641e33f602b9b72468885f2505c59c536af", size = 86121, upload-time = "2026-02-06T19:56:22.07Z" },
+]
+
+[[package]]
 name = "shellingham"
 version = "1.5.4"
 source = { registry = "https://pypi.org/simple" }
@@ -6109,6 +6160,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/df/3d/9e7eee57b37c80cec63322c0231bb6da3cfe535a91d7a4d64896fcb89357/triton-3.6.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a17a5d5985f0ac494ed8a8e54568f092f7057ef60e1b0fa09d3fd1512064e803", size = 188273063, upload-time = "2026-01-20T16:01:07.278Z" },
     { url = "https://files.pythonhosted.org/packages/48/db/56ee649cab5eaff4757541325aca81f52d02d4a7cd3506776cad2451e060/triton-3.6.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0b3a97e8ed304dfa9bd23bb41ca04cdf6b2e617d5e782a8653d616037a5d537d", size = 176274804, upload-time = "2026-01-20T16:16:31.528Z" },
     { url = "https://files.pythonhosted.org/packages/f6/56/6113c23ff46c00aae423333eb58b3e60bdfe9179d542781955a5e1514cb3/triton-3.6.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:46bd1c1af4b6704e554cad2eeb3b0a6513a980d470ccfa63189737340c7746a7", size = 188397994, upload-time = "2026-01-20T16:01:14.236Z" },
+]
+
+[[package]]
+name = "truststore"
+version = "0.10.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
<details><summary>AI generated PR description</summary>

## Summary

- Adds a `SUBSAMPLE = True` toggle to `example-pipeline.py` and `example-group-template.py` so users can quickly run through the notebooks at lower spatial resolution
- Adds `subsample_volume()` in `util.py` (stride-based, takes every Nth voxel) and `subsample_dwi()` in `dwi.py`
- Adds `openneuro-py` to the `[notebooks]` dependency group (the old pip-install-on-import pattern doesn't work with uv)
- Cleans up `notebooks/README.md`

## How subsampling works

Stride-based: `arr[::factor, ::factor, ::factor]` on the 3 spatial dims, affine scaled to match. Not interpolated resampling — just a quick way to shrink data for trying things out.

</details>

Closes #124