### PR TITLE
Add pipeline caching via Cache

### DIFF
--- a/docs/tutorials/example-pipeline.md
+++ b/docs/tutorials/example-pipeline.md
@@ -397,3 +397,88 @@ dwi_denoised.save(output_dir, basename="denoised_dwi")
 
 print(f"Results saved to {output_dir.resolve()}")
 ```
+
+## Pipeline caching
+
+Wrapping pipeline steps in a `Cache` context manager enables automatic
+disk-based caching. Key behaviours:
+
+- **First run:** results are computed and saved to `cache_dir`.
+- **Subsequent runs:** results are loaded from disk, skipping the computation.
+- **Scalar parameters** (`int`, `float`, `str`, `bool`) are stored as
+  human-readable JSON and fingerprinted — changing a value invalidates that
+  step's cache.
+- **Input data** (volumes, b-values, b-vectors, masks, response functions) are
+  sha256-fingerprinted — if the underlying data changes, the cache is
+  invalidated automatically.
+- **Forced recomputation:** pass `force={"step_name"}` or `force=True` to
+  rerun a specific step or all steps regardless of cache state.
+
+
+```python
+from kwneuro.cache import Cache
+from kwneuro.dti import Dti
+from kwneuro.noddi import Noddi
+
+cache_dir = Path("cache")
+
+with Cache(cache_dir) as pc:
+    dti = dwi_denoised.estimate_dti(mask=mask)
+    noddi = dwi_denoised.estimate_noddi(mask=mask)
+    _, peaks = compute_csd_peaks(dwi_denoised, mask, response)
+```
+
+
+```python
+status = pc.status([Dti.estimate_dti, Noddi.estimate_noddi, compute_csd_peaks])
+print("Cache status:")
+for step, is_cached in status.items():
+    print(f"  {step}: {'cached' if is_cached else 'not cached'}")
+```
+
+    Cache status:
+      Dti.estimate_dti: cached
+      Noddi.estimate_noddi: cached
+      compute_csd_peaks: cached
+
+
+Quick look at the `.params.json` file saved alongside each cached step.
+The sidecar has two sections:
+
+- `scalars` — scalar parameters stored as human-readable JSON, so you can
+  inspect exactly what values were used to produce the cached result.
+- `hashes` — sha256 fingerprints of non-scalar inputs (DWI volume,
+  b-values, b-vectors, mask, response function, etc.). If the underlying data
+  changes between runs, the hash changes and the cache is invalidated.
+
+
+```python
+import json
+
+print("Files in cache_dir:")
+for f in sorted(cache_dir.iterdir()):
+    print(f"  {f.name}")
+
+print("\nestimate_dti.params.json:")
+sidecar = json.loads((cache_dir / "estimate_dti.params.json").read_text())
+print(json.dumps(sidecar, indent=2))
+```
+
+    Files in cache_dir:
+      compute_csd_peaks.params.json
+      csd_peak_dirs.nii.gz
+      csd_peak_values.nii.gz
+      estimate_dti.nii.gz
+      estimate_dti.params.json
+      estimate_noddi.nii.gz
+      estimate_noddi.params.json
+      estimate_noddi_directions.nii.gz
+    
+    estimate_dti.params.json:
+    {
+      "hashes": {
+        "dwi": "a0b14d69557b8bdba79063cd935673b8c114ffaf1c3756b87c2c930d905abc6a",
+        "mask": "454054019b2fb1265fbeca5db8fb65b1701390a75d443c974e4f9896f8a71953"
+      }
+    }
+

--- a/notebooks/example-pipeline.py
+++ b/notebooks/example-pipeline.py
@@ -366,7 +366,7 @@ print(f"Results saved to {output_dir.resolve()}")
 # - **Forced recomputation:** pass `force={"step_name"}` or `force=True` to
 #   rerun a specific step or all steps regardless of cache state.
 
-# %%
+# %% tags=["remove-output"]
 from kwneuro.cache import Cache
 from kwneuro.dti import Dti
 from kwneuro.noddi import Noddi
@@ -378,6 +378,7 @@ with Cache(cache_dir) as pc:
     noddi = dwi_denoised.estimate_noddi(mask=mask)
     _, peaks = compute_csd_peaks(dwi_denoised, mask, response)
 
+# %%
 status = pc.status([Dti.estimate_dti, Noddi.estimate_noddi, compute_csd_peaks])
 print("Cache status:")
 for step, is_cached in status.items():

--- a/notebooks/example-pipeline.py
+++ b/notebooks/example-pipeline.py
@@ -352,13 +352,19 @@ print(f"Results saved to {output_dir.resolve()}")
 # %% [markdown]
 # ## Pipeline caching
 #
-# Wrapping pipeline steps in a `Cache` context saves results to disk
-# on the first run and reloads them automatically on subsequent runs, skipping
-# the underlying computation. Scalar parameters (`int`, `float`, `str`, `bool`)
-# are fingerprinted automatically — changing them invalidates only that step's
-# cache. Use a separate `cache_dir` per subject so cached results stay isolated.
-# Pass `force={"step_name"}` (or `force=True`) to recompute a specific step or
-# all steps.
+# Wrapping pipeline steps in a `Cache` context manager enables automatic
+# disk-based caching. Key behaviours:
+#
+# - **First run:** results are computed and saved to `cache_dir`.
+# - **Subsequent runs:** results are loaded from disk, skipping the computation.
+# - **Scalar parameters** (`int`, `float`, `str`, `bool`) are stored as
+#   human-readable JSON and fingerprinted — changing a value invalidates that
+#   step's cache.
+# - **Input data** (volumes, b-values, b-vectors, masks, response functions) are
+#   sha256-fingerprinted — if the underlying data changes, the cache is
+#   invalidated automatically.
+# - **Forced recomputation:** pass `force={"step_name"}` or `force=True` to
+#   rerun a specific step or all steps regardless of cache state.
 
 # %%
 from kwneuro.cache import Cache
@@ -368,11 +374,32 @@ from kwneuro.noddi import Noddi
 cache_dir = Path("cache")
 
 with Cache(cache_dir) as pc:
-    dti_cached = dwi_denoised.estimate_dti(mask=mask)
-    noddi_cached = dwi_denoised.estimate_noddi(mask=mask)
-    _, peaks_cached = compute_csd_peaks(dwi_denoised, mask, response)
+    dti = dwi_denoised.estimate_dti(mask=mask)
+    noddi = dwi_denoised.estimate_noddi(mask=mask)
+    _, peaks = compute_csd_peaks(dwi_denoised, mask, response)
 
 status = pc.status([Dti.estimate_dti, Noddi.estimate_noddi, compute_csd_peaks])
 print("Cache status:")
 for step, is_cached in status.items():
     print(f"  {step}: {'cached' if is_cached else 'not cached'}")
+
+# %% [markdown]
+# Quick look at the `.params.json` file saved alongside each cached step.
+# The sidecar has two sections:
+#
+# - `scalars` — scalar parameters stored as human-readable JSON, so you can
+#   inspect exactly what values were used to produce the cached result.
+# - `hashes` — sha256 fingerprints of non-scalar inputs (DWI volume,
+#   b-values, b-vectors, mask, response function, etc.). If the underlying data
+#   changes between runs, the hash changes and the cache is invalidated.
+
+# %%
+import json
+
+print("Files in cache_dir:")
+for f in sorted(cache_dir.iterdir()):
+    print(f"  {f.name}")
+
+print("\nestimate_dti.params.json:")
+sidecar = json.loads((cache_dir / "estimate_dti.params.json").read_text())
+print(json.dumps(sidecar, indent=2))

--- a/notebooks/example-pipeline.py
+++ b/notebooks/example-pipeline.py
@@ -348,3 +348,31 @@ NiftiVolumeResource.save(mask, output_dir / "brain_mask.nii.gz")
 dwi_denoised.save(output_dir, basename="denoised_dwi")
 
 print(f"Results saved to {output_dir.resolve()}")
+
+# %% [markdown]
+# ## Pipeline caching
+#
+# Wrapping pipeline steps in a `PipelineCache` context saves results to disk
+# on the first run and reloads them automatically on subsequent runs, skipping
+# the underlying computation. Scalar parameters (`int`, `float`, `str`, `bool`)
+# are fingerprinted automatically — changing them invalidates only that step's
+# cache. Use a separate `cache_dir` per subject so cached results stay isolated.
+# Pass `force={"step_name"}` (or `force=True`) to recompute a specific step or
+# all steps.
+
+# %%
+from kwneuro.cache import PipelineCache
+from kwneuro.dti import Dti
+from kwneuro.noddi import Noddi
+
+cache_dir = Path("cache")
+
+with PipelineCache(cache_dir) as pc:
+    dti_cached = dwi_denoised.estimate_dti(mask=mask)
+    noddi_cached = dwi_denoised.estimate_noddi(mask=mask)
+    _, peaks_cached = compute_csd_peaks(dwi_denoised, mask, response)
+
+status = pc.status([Dti.estimate_from_dwi, Noddi.estimate_from_dwi, compute_csd_peaks])
+print("Cache status:")
+for step, is_cached in status.items():
+    print(f"  {step}: {'cached' if is_cached else 'not cached'}")

--- a/notebooks/example-pipeline.py
+++ b/notebooks/example-pipeline.py
@@ -352,7 +352,7 @@ print(f"Results saved to {output_dir.resolve()}")
 # %% [markdown]
 # ## Pipeline caching
 #
-# Wrapping pipeline steps in a `PipelineCache` context saves results to disk
+# Wrapping pipeline steps in a `Cache` context saves results to disk
 # on the first run and reloads them automatically on subsequent runs, skipping
 # the underlying computation. Scalar parameters (`int`, `float`, `str`, `bool`)
 # are fingerprinted automatically — changing them invalidates only that step's
@@ -361,13 +361,13 @@ print(f"Results saved to {output_dir.resolve()}")
 # all steps.
 
 # %%
-from kwneuro.cache import PipelineCache
+from kwneuro.cache import Cache
 from kwneuro.dti import Dti
 from kwneuro.noddi import Noddi
 
 cache_dir = Path("cache")
 
-with PipelineCache(cache_dir) as pc:
+with Cache(cache_dir) as pc:
     dti_cached = dwi_denoised.estimate_dti(mask=mask)
     noddi_cached = dwi_denoised.estimate_noddi(mask=mask)
     _, peaks_cached = compute_csd_peaks(dwi_denoised, mask, response)

--- a/notebooks/example-pipeline.py
+++ b/notebooks/example-pipeline.py
@@ -372,7 +372,7 @@ with PipelineCache(cache_dir) as pc:
     noddi_cached = dwi_denoised.estimate_noddi(mask=mask)
     _, peaks_cached = compute_csd_peaks(dwi_denoised, mask, response)
 
-status = pc.status([Dti.estimate_from_dwi, Noddi.estimate_from_dwi, compute_csd_peaks])
+status = pc.status([Dti.estimate_dti, Noddi.estimate_noddi, compute_csd_peaks])
 print("Cache status:")
 for step, is_cached in status.items():
     print(f"  {step}: {'cached' if is_cached else 'not cached'}")

--- a/src/kwneuro/__init__.py
+++ b/src/kwneuro/__init__.py
@@ -7,5 +7,6 @@ kwneuro: Processing pipelines to extract brain microstructure from diffusion MRI
 from __future__ import annotations
 
 from ._version import version as __version__
+from .cache import CacheSpec, PipelineCache, cacheable
 
-__all__ = ["__version__"]
+__all__ = ["CacheSpec", "PipelineCache", "__version__", "cacheable"]

--- a/src/kwneuro/__init__.py
+++ b/src/kwneuro/__init__.py
@@ -7,6 +7,6 @@ kwneuro: Processing pipelines to extract brain microstructure from diffusion MRI
 from __future__ import annotations
 
 from ._version import version as __version__
-from .cache import CacheSpec, PipelineCache, cacheable
+from .cache import Cache, CacheSpec, cacheable
 
-__all__ = ["CacheSpec", "PipelineCache", "__version__", "cacheable"]
+__all__ = ["Cache", "CacheSpec", "__version__", "cacheable"]

--- a/src/kwneuro/cache.py
+++ b/src/kwneuro/cache.py
@@ -12,7 +12,7 @@ from typing import Any, Generic, TypeVar
 
 T = TypeVar("T")
 
-_active_cache: contextvars.ContextVar[PipelineCache | None] = contextvars.ContextVar(
+_active_cache: contextvars.ContextVar[Cache | None] = contextvars.ContextVar(
     "_active_cache", default=None
 )
 
@@ -48,7 +48,7 @@ class _CacheInfo:
 
 
 @dataclass
-class PipelineCache:
+class Cache:
     """Context manager that activates caching for all ``@cacheable``-decorated
     functions within a ``with`` block.
 
@@ -69,7 +69,7 @@ class PipelineCache:
         self.cache_dir = Path(self.cache_dir)
         self.cache_dir.mkdir(parents=True, exist_ok=True)
 
-    def __enter__(self) -> PipelineCache:
+    def __enter__(self) -> Cache:
         self._token = _active_cache.set(self)
         return self
 
@@ -139,12 +139,12 @@ def _resolve_return_type(fn: Callable[..., Any]) -> type | None:
     if ann is None:
         return None
     if not isinstance(ann, str):
-        return ann  # type: ignore[return-value]
+        return ann  # type: ignore[no-any-return]
     module = sys.modules.get(fn.__module__)
     if module is None:
         return None
     try:
-        return eval(ann, vars(module))
+        return eval(ann, vars(module))  # type: ignore[no-any-return]
     except Exception:
         return None
 
@@ -190,9 +190,9 @@ def _save_params(
     )
 
 
-def cacheable(fn_or_spec: Callable[..., Any] | CacheSpec[Any]) -> Any:  # type: ignore[return]
-    """Decorator that adds transparent caching when a :class:`PipelineCache`
-    context is active.  Outside a ``with PipelineCache(...)`` block the
+def cacheable(fn_or_spec: Callable[..., Any] | CacheSpec[Any]) -> Any:
+    """Decorator that adds transparent caching when a :class:`Cache`
+    context is active.  Outside a ``with Cache(...)`` block the
     function runs normally with no caching overhead.
 
     Two styles:
@@ -237,9 +237,9 @@ def cacheable(fn_or_spec: Callable[..., Any] | CacheSpec[Any]) -> Any:  # type: 
     # name isn't yet in the module namespace at decoration time.
     fn = fn_or_spec
     step_name = fn.__name__
-    _resolved_type: type | None = None
+    _resolved_type: Any = None
 
-    def _get_return_type() -> type:
+    def _get_return_type() -> Any:
         nonlocal _resolved_type
         if _resolved_type is None:
             rt = _resolve_return_type(fn)

--- a/src/kwneuro/cache.py
+++ b/src/kwneuro/cache.py
@@ -1,14 +1,19 @@
 from __future__ import annotations
 
 import contextvars
+import dataclasses
 import functools
+import hashlib
 import inspect
 import json
 import sys
+import warnings
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Generic, TypeVar
+
+import numpy as np
 
 T = TypeVar("T")
 
@@ -16,27 +21,30 @@ _active_cache: contextvars.ContextVar[Cache | None] = contextvars.ContextVar(
     "_active_cache", default=None
 )
 
+# Scalar types are stored verbatim as human-readable JSON in the params sidecar.
+# All other argument types go through content fingerprinting (see _compute_fingerprint).
+_SCALAR_TYPES = (bool, int, float, str, type(None))
+
 
 @dataclass
 class CacheSpec(Generic[T]):
-    """Explicit cache spec for ``@cacheable`` when the return type cannot carry
-    the cache protocol (e.g. tuples, plain arrays).
+    """Explicit cache spec for ``@cacheable`` when the return type does not implement the cache protocol.
 
     Use the bare ``@cacheable`` decorator instead when the return type implements
-    ``_cache_files`` / ``_cache_save`` / ``_cache_load``.
+    ``_cache_files``, ``_cache_save``, and ``_cache_load``.
     """
 
     files: list[str]
-    """Filenames relative to ``cache_dir`` that constitute the cached output."""
+    """Output filenames relative to the cache directory."""
 
     save: Callable[[T, Path], None]
-    """Persist *result* to *cache_dir*."""
+    """Callable that persists the result to the cache directory."""
 
     load: Callable[[Path], T]
-    """Reconstruct the result from *cache_dir*."""
+    """Callable that reconstructs the result from the cache directory."""
 
     step_name: str = ""
-    """Step name override. Defaults to the decorated function's ``__name__``."""
+    """Step name used to identify this step in the params sidecar. Defaults to the decorated function name."""
 
 
 @dataclass
@@ -49,21 +57,24 @@ class _CacheInfo:
 
 @dataclass
 class Cache:
-    """Context manager that activates caching for all ``@cacheable``-decorated
-    functions within a ``with`` block.
+    """Context manager that activates caching for all ``@cacheable``-decorated functions.
 
-    ``cache_dir`` is created automatically. ``force`` controls cache bypass:
-    ``False`` (default) uses all cached outputs; ``True`` recomputes everything;
-    a ``set[str]`` of step names recomputes only those steps.
-
-    Scalar arguments (``int``, ``float``, ``str``, ``bool``, ``None``) are
-    fingerprinted — if they change between runs the step recomputes automatically.
-    Non-scalar arguments are not tracked; use ``force={"step_name"}`` when those
-    change.  Each subject should use a distinct ``cache_dir`` to avoid races.
+    Scalar arguments and imaging data arguments are fingerprinted automatically.
+    Changes to either trigger a cache miss on the next run. Arguments that cannot
+    be fingerprinted issue a UserWarning. Each subject should use a distinct
+    cache_dir to avoid races.
     """
 
     cache_dir: Path
+    """Directory where cached outputs and per-step sidecar files are stored. Created automatically."""
+
     force: bool | set[str] = field(default=False)
+    """Cache bypass control. False uses all cached outputs, True recomputes everything,
+    a set of step names recomputes only those steps."""
+
+    _token: contextvars.Token[Cache | None] | None = field(
+        init=False, default=None, repr=False
+    )
 
     def __post_init__(self) -> None:
         self.cache_dir = Path(self.cache_dir)
@@ -74,10 +85,12 @@ class Cache:
         return self
 
     def __exit__(self, *_: Any) -> None:
-        _active_cache.reset(self._token)
+        if self._token is not None:
+            _active_cache.reset(self._token)
+            self._token = None
 
     def is_forced(self, step_name: str) -> bool:
-        """Return ``True`` if this step should bypass the cache."""
+        """Return True if this step should bypass the cache."""
         if isinstance(self.force, set):
             return step_name in self.force
         return bool(self.force)
@@ -86,31 +99,52 @@ class Cache:
         self,
         step_name: str,
         files: list[str],
-        params: dict[str, Any] | None = None,
+        scalars: dict[str, Any] | None = None,
+        hashes: dict[str, str] | None = None,
     ) -> bool:
-        """Return ``True`` when all output files exist, the step is not forced,
-        and (if *params* is given) the stored parameter fingerprint matches.
+        """Return True when all output files exist, the step is not forced, and the stored fingerprint matches.
+
+        The sidecar file stores two sections: "scalars" for human-readable scalar argument
+        values and "hashes" for sha256 content fingerprints. A mismatch in either section,
+        or a missing sidecar when params are expected, is treated as a cache miss.
+
+        Args:
+            step_name: Name of the cache step, used to locate the sidecar file.
+            files: Output filenames relative to cache_dir that must all exist for a cache hit.
+            scalars: Scalar argument values to compare against the stored sidecar, or None.
+            hashes: Content fingerprints to compare against the stored sidecar, or None.
+
+        Returns: True on a cache hit, False on a miss.
         """
         if self.is_forced(step_name):
             return False
         if not all((self.cache_dir / f).exists() for f in files):
             return False
-        if params:
+        if scalars or hashes:
             params_file = self.cache_dir / f"{step_name}.params.json"
             if not params_file.exists():
                 return False
             try:
                 stored = json.loads(params_file.read_text(encoding="utf-8"))
-                if stored != params:
+                # Compare the scalars section (human-readable parameter values).
+                if scalars and stored.get("scalars") != scalars:
                     return False
-            except Exception:
+                # Compare the hashes section (content fingerprints for imaging data).
+                if hashes and stored.get("hashes") != hashes:
+                    return False
+            except Exception:  # pylint: disable=broad-exception-caught
                 return False
         return True
 
     def status(self, steps: list[Callable[..., Any]]) -> dict[str, bool]:
-        """Return a dict mapping ``fn.__qualname__`` → ``True/False`` indicating
-        whether all cached output files exist for each ``@cacheable`` step.
-        Non-decorated callables in *steps* are silently skipped.
+        """Return a mapping of each step's qualified name to whether all its cached output files exist.
+
+        Non-decorated callables in steps are silently skipped.
+
+        Args:
+            steps: List of cacheable-decorated functions to check.
+
+        Returns: Dict mapping fn.__qualname__ to True if all cached outputs exist, False otherwise.
         """
         result: dict[str, bool] = {}
         for fn in steps:
@@ -123,17 +157,120 @@ class Cache:
 
 
 # ---------------------------------------------------------------------------
+# Fingerprinting
+# ---------------------------------------------------------------------------
+# The fingerprinting system converts any argument value into a stable sha256
+# hex string so that changes to imaging data — not just scalar parameters —
+# trigger a cache miss.  All logic lives here; no cache-related methods are
+# added to resource or data classes.
+
+
+def _compute_fingerprint(v: Any) -> str | None:
+    """Compute a stable sha256 fingerprint string for v, or None if v cannot be fingerprinted.
+
+    Handles scalars, numpy arrays, numpy scalars, Path, dict, list/tuple, and dataclass
+    instances recursively. Dataclass support covers the full resource hierarchy (Dwi,
+    VolumeResource, etc.) without importing those types. Returns None for unrecognised
+    types; the caller issues a UserWarning in that case.
+
+    Args:
+        v: The value to fingerprint.
+
+    Returns: A sha256 hex digest string, or None if v cannot be fingerprinted.
+    """
+    h = hashlib.sha256()
+
+    # --- Scalars ---
+    # bool must be checked before int because bool is a subclass of int.
+    if v is None:
+        h.update(b"None:")
+        return h.hexdigest()
+    if isinstance(v, bool):
+        h.update(f"bool:{v}".encode())
+        return h.hexdigest()
+    if isinstance(v, int):
+        h.update(f"int:{v}".encode())
+        return h.hexdigest()
+    if isinstance(v, float):
+        # Use repr for floats to preserve full precision.
+        h.update(f"float:{v!r}".encode())
+        return h.hexdigest()
+    if isinstance(v, str):
+        h.update(f"str:{v}".encode())
+        return h.hexdigest()
+
+    # --- numpy arrays ---
+    # Hash raw bytes plus shape and dtype so arrays with the same bytes but
+    # different shapes (e.g. (2,3) vs (6,)) produce different fingerprints.
+    if isinstance(v, np.ndarray):
+        h.update(v.tobytes())
+        h.update(f"|shape={v.shape}|dtype={v.dtype}".encode())
+        return h.hexdigest()
+
+    # --- numpy scalar types (np.float32, np.int64, etc.) ---
+    if isinstance(v, np.generic):
+        h.update(f"npscalar:{type(v).__name__}:{v!r}".encode())
+        return h.hexdigest()
+
+    # --- Path objects ---
+    # Disk resources (NiftiVolumeResource, FslBvalResource, etc.) store their
+    # data as a Path field, so this gives them a path-identity fingerprint.
+    if isinstance(v, Path):
+        h.update(f"path:{v}".encode())
+        return h.hexdigest()
+
+    # --- Dicts ---
+    # Sort by key string for determinism across runs.
+    if isinstance(v, dict):
+        parts = []
+        for k, dv in sorted(v.items(), key=lambda item: str(item[0])):
+            fp = _compute_fingerprint(dv)
+            if fp is None:
+                return None  # a dict value is untrackable → whole dict is untrackable
+            parts.append(f"{k}:{fp}")
+        h.update("|".join(parts).encode())
+        return h.hexdigest()
+
+    # --- Lists and tuples ---
+    if isinstance(v, (list, tuple)):
+        parts = []
+        for item in v:
+            fp = _compute_fingerprint(item)
+            if fp is None:
+                return None
+            parts.append(fp)
+        h.update("|".join(parts).encode())
+        return h.hexdigest()
+
+    # --- Dataclass instances ---
+    # Covers Dwi, InMemoryVolumeResource, NiftiVolumeResource, InMemoryBvalResource,
+    # InMemoryBvecResource, InMemoryResponseFunctionResource, and any future
+    # resource types, as long as their fields are among the supported types above.
+    # The `not isinstance(v, type)` guard excludes dataclass *classes* themselves.
+    if dataclasses.is_dataclass(v) and not isinstance(v, type):
+        parts = []
+        for f in dataclasses.fields(v):
+            fp = _compute_fingerprint(getattr(v, f.name))
+            if fp is None:
+                return None  # an untrackable field → whole dataclass is untrackable
+            parts.append(f"{f.name}:{fp}")
+        h.update("|".join(parts).encode())
+        return h.hexdigest()
+
+    # Unrecognised type — the caller will warn that this argument is not tracked.
+    return None
+
+
+# ---------------------------------------------------------------------------
 # Internal helpers
 # ---------------------------------------------------------------------------
 
 
 def _resolve_return_type(fn: Callable[..., Any]) -> type | None:
-    """Resolve the return-type annotation without calling ``get_type_hints()``.
+    """Resolve the return-type annotation for fn without calling get_type_hints().
 
-    ``get_type_hints()`` resolves *all* annotations and raises ``NameError``
-    for ``TYPE_CHECKING``-only imports (e.g. ``Dwi`` in ``csd.py``).  We only
-    need the return annotation, so we evaluate just that string in the
-    function's module namespace.
+    get_type_hints() raises NameError for TYPE_CHECKING-only imports (e.g. Dwi in csd.py).
+    Evaluates only the return annotation string in the function's own module namespace.
     """
     ann = fn.__annotations__.get("return")
     if ann is None:
@@ -144,8 +281,8 @@ def _resolve_return_type(fn: Callable[..., Any]) -> type | None:
     if module is None:
         return None
     try:
-        return eval(ann, vars(module))  # type: ignore[no-any-return]
-    except Exception:
+        return eval(ann, vars(module))  # type: ignore[no-any-return]  # pylint: disable=eval-used
+    except Exception:  # pylint: disable=broad-exception-caught
         return None
 
 
@@ -157,53 +294,112 @@ def _has_cache_protocol(t: Any) -> bool:
     )
 
 
-def _extract_scalar_params(
+def _extract_params(
     fn: Callable[..., Any],
     args: tuple[Any, ...],
     kwargs: dict[str, Any],
-) -> dict[str, Any] | None:
-    """Extract scalar (``int``, ``float``, ``str``, ``bool``, ``None``) arguments
-    from a call for parameter fingerprinting.  Non-scalar args are silently
-    skipped.  Returns ``None`` if no scalar args are present.
+) -> tuple[dict[str, Any] | None, dict[str, str] | None]:
+    """Classify bound arguments into scalars, content fingerprints, or untracked.
+
+    Scalar arguments (bool, int, float, str, None) are stored verbatim. Fingerprint-able
+    arguments (dataclasses, numpy arrays, Path, etc.) are stored as sha256 hex digests.
+    Untracked arguments trigger a UserWarning.
+
+    Args:
+        fn: The wrapped function, used for signature binding and warning messages.
+        args: Positional arguments from the call.
+        kwargs: Keyword arguments from the call.
+
+    Returns: Tuple of (scalars dict or None, hashes dict or None).
     """
     try:
         sig = inspect.signature(fn)
         bound = sig.bind(*args, **kwargs)
         bound.apply_defaults()
-    except Exception:
-        return None
-    params = {
-        k: v
-        for k, v in bound.arguments.items()
-        if isinstance(v, (int, float, str, bool, type(None)))
-    }
-    return params or None
+    except Exception:  # pylint: disable=broad-exception-caught
+        return None, None
+
+    scalars: dict[str, Any] = {}
+    hashes: dict[str, str] = {}
+
+    for k, v in bound.arguments.items():
+        if isinstance(v, _SCALAR_TYPES):
+            # Scalar — store as a human-readable JSON value (e.g. dpar=1.7e-3).
+            scalars[k] = v
+        else:
+            fp = _compute_fingerprint(v)
+            if fp is not None:
+                # Content-fingerprint-able (e.g. Dwi, VolumeResource).
+                # Any change to the underlying data will produce a different
+                # sha256 and cause a cache miss on the next run.
+                hashes[k] = fp
+            else:
+                # Cannot fingerprint — warn so the user knows this argument
+                # is invisible to the cache and won't trigger recomputation.
+                warnings.warn(
+                    f"@cacheable: parameter '{k}' of type '{type(v).__name__}' "
+                    f"in '{fn.__qualname__}' cannot be fingerprinted and will not "
+                    "be tracked for cache invalidation. "
+                    f"Use force={{'{fn.__name__}'}} to force recomputation "
+                    "when this input changes.",
+                    UserWarning,
+                    stacklevel=4,
+                )
+
+    return scalars or None, hashes or None
 
 
 def _save_params(
-    cache_dir: Path, step_name: str, params: dict[str, Any] | None
+    cache_dir: Path,
+    step_name: str,
+    scalars: dict[str, Any] | None,
+    hashes: dict[str, str] | None,
 ) -> None:
-    if not params:
+    """Write scalar params and content hashes to {step_name}.params.json.
+
+    The sidecar stores two sections: "scalars" for human-readable scalar argument values
+    and "hashes" for sha256 content fingerprints. No file is written if both are empty.
+
+    Args:
+        cache_dir: Directory where the sidecar file is written.
+        step_name: Used to name the sidecar file ({step_name}.params.json).
+        scalars: Scalar argument values to persist, or None.
+        hashes: Content fingerprints to persist, or None.
+    """
+    if not scalars and not hashes:
         return
+    data: dict[str, Any] = {}
+    if scalars:
+        data["scalars"] = scalars
+    if hashes:
+        data["hashes"] = hashes
     (cache_dir / f"{step_name}.params.json").write_text(
-        json.dumps(params, sort_keys=True), encoding="utf-8"
+        json.dumps(data, sort_keys=True), encoding="utf-8"
     )
 
 
 def cacheable(fn_or_spec: Callable[..., Any] | CacheSpec[Any]) -> Any:
-    """Decorator that adds transparent caching when a :class:`Cache`
-    context is active.  Outside a ``with Cache(...)`` block the
-    function runs normally with no caching overhead.
+    """Decorator that adds transparent caching when a Cache context is active.
 
-    Two styles:
+    Outside a ``with Cache(...)`` block the function runs normally with no overhead.
+    Scalar and dataclass arguments are fingerprinted automatically; a change in either
+    causes a cache miss. Arguments that cannot be fingerprinted trigger a UserWarning.
 
-    - **Bare** ``@cacheable`` — return type must implement the cache protocol
-      (``_cache_files``, ``_cache_save``, ``_cache_load``).
-    - **Explicit spec** ``@cacheable(CacheSpec(...))`` — for return types that
-      cannot carry the protocol (tuples, arrays, etc.).
+    Can be used in two ways. As a bare decorator when the return type implements
+    the cache protocol (_cache_files, _cache_save, _cache_load)::
 
-    Scalar arguments are fingerprinted automatically; a change forces recompute.
+        @cacheable
+        def estimate_dti(dwi: Dwi, mask: VolumeResource | None = None) -> Dti: ...
+
+    Or with an explicit CacheSpec for return types that cannot carry the protocol::
+
+        @cacheable(CacheSpec(files=[...], save=..., load=...))
+        def compute_csd_peaks(...) -> tuple[VolumeResource, VolumeResource]: ...
     """
+    # The cache protocol methods (_cache_files, _cache_save, _cache_load, _cache_info)
+    # are prefixed with _ to mark them as internal to the caching infrastructure, not
+    # as truly protected class members. cacheable() is the intended call site for all of them.
+    # pylint: disable=protected-access
     if isinstance(fn_or_spec, CacheSpec):
         spec: CacheSpec[Any] = fn_or_spec
 
@@ -214,13 +410,17 @@ def cacheable(fn_or_spec: Callable[..., Any] | CacheSpec[Any]) -> Any:
             def _wrapper(*args: Any, **kwargs: Any) -> Any:
                 cache = _active_cache.get()
                 if cache is None:
+                    # No active Cache context — run the function as-is.
                     return fn(*args, **kwargs)
-                params = _extract_scalar_params(fn, args, kwargs)
-                if cache.is_cached(step_name, spec.files, params):
+                # Classify arguments into scalars and content hashes.
+                scalars, hashes = _extract_params(fn, args, kwargs)
+                if cache.is_cached(step_name, spec.files, scalars, hashes):
+                    # All output files exist and the fingerprint matches — load from disk.
                     return spec.load(cache.cache_dir)
+                # Cache miss: run the function, persist the outputs, save the fingerprint.
                 result = fn(*args, **kwargs)
                 spec.save(result, cache.cache_dir)
-                _save_params(cache.cache_dir, step_name, params)
+                _save_params(cache.cache_dir, step_name, scalars, hashes)
                 return spec.load(cache.cache_dir)
 
             _wrapper._cache_info = _CacheInfo(  # type: ignore[attr-defined]
@@ -259,15 +459,19 @@ def cacheable(fn_or_spec: Callable[..., Any] | CacheSpec[Any]) -> Any:
     def _wrapper(*args: Any, **kwargs: Any) -> Any:
         cache = _active_cache.get()
         if cache is None:
+            # No active Cache context — run the function as-is.
             return fn(*args, **kwargs)
         rt = _get_return_type()
-        params = _extract_scalar_params(fn, args, kwargs)
+        # Classify arguments into scalars and content hashes.
+        scalars, hashes = _extract_params(fn, args, kwargs)
         files = rt._cache_files(step_name)
-        if cache.is_cached(step_name, files, params):
+        if cache.is_cached(step_name, files, scalars, hashes):
+            # All output files exist and the fingerprint matches — load from disk.
             return rt._cache_load(cache.cache_dir, step_name)
+        # Cache miss: run the function, persist the output, save the fingerprint.
         result = fn(*args, **kwargs)
         result._cache_save(cache.cache_dir, step_name)
-        _save_params(cache.cache_dir, step_name, params)
+        _save_params(cache.cache_dir, step_name, scalars, hashes)
         return rt._cache_load(cache.cache_dir, step_name)
 
     _wrapper._cache_info = _CacheInfo(  # type: ignore[attr-defined]

--- a/src/kwneuro/cache.py
+++ b/src/kwneuro/cache.py
@@ -1,0 +1,277 @@
+from __future__ import annotations
+
+import contextvars
+import functools
+import inspect
+import json
+import sys
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Generic, TypeVar
+
+T = TypeVar("T")
+
+_active_cache: contextvars.ContextVar[PipelineCache | None] = contextvars.ContextVar(
+    "_active_cache", default=None
+)
+
+
+@dataclass
+class CacheSpec(Generic[T]):
+    """Explicit cache spec for ``@cacheable`` when the return type cannot carry
+    the cache protocol (e.g. tuples, plain arrays).
+
+    Use the bare ``@cacheable`` decorator instead when the return type implements
+    ``_cache_files`` / ``_cache_save`` / ``_cache_load``.
+    """
+
+    files: list[str]
+    """Filenames relative to ``cache_dir`` that constitute the cached output."""
+
+    save: Callable[[T, Path], None]
+    """Persist *result* to *cache_dir*."""
+
+    load: Callable[[Path], T]
+    """Reconstruct the result from *cache_dir*."""
+
+    step_name: str = ""
+    """Step name override. Defaults to the decorated function's ``__name__``."""
+
+
+@dataclass
+class _CacheInfo:
+    """Internal metadata attached to each @cacheable-decorated function."""
+
+    step_name: str
+    get_files: Callable[[str], list[str]]
+
+
+@dataclass
+class PipelineCache:
+    """Context manager that activates caching for all ``@cacheable``-decorated
+    functions within a ``with`` block.
+
+    ``cache_dir`` is created automatically. ``force`` controls cache bypass:
+    ``False`` (default) uses all cached outputs; ``True`` recomputes everything;
+    a ``set[str]`` of step names recomputes only those steps.
+
+    Scalar arguments (``int``, ``float``, ``str``, ``bool``, ``None``) are
+    fingerprinted — if they change between runs the step recomputes automatically.
+    Non-scalar arguments are not tracked; use ``force={"step_name"}`` when those
+    change.  Each subject should use a distinct ``cache_dir`` to avoid races.
+    """
+
+    cache_dir: Path
+    force: bool | set[str] = field(default=False)
+
+    def __post_init__(self) -> None:
+        self.cache_dir = Path(self.cache_dir)
+        self.cache_dir.mkdir(parents=True, exist_ok=True)
+
+    def __enter__(self) -> PipelineCache:
+        self._token = _active_cache.set(self)
+        return self
+
+    def __exit__(self, *_: Any) -> None:
+        _active_cache.reset(self._token)
+
+    def is_forced(self, step_name: str) -> bool:
+        """Return ``True`` if this step should bypass the cache."""
+        if isinstance(self.force, set):
+            return step_name in self.force
+        return bool(self.force)
+
+    def is_cached(
+        self,
+        step_name: str,
+        files: list[str],
+        params: dict[str, Any] | None = None,
+    ) -> bool:
+        """Return ``True`` when all output files exist, the step is not forced,
+        and (if *params* is given) the stored parameter fingerprint matches.
+        """
+        if self.is_forced(step_name):
+            return False
+        if not all((self.cache_dir / f).exists() for f in files):
+            return False
+        if params:
+            params_file = self.cache_dir / f"{step_name}.params.json"
+            if not params_file.exists():
+                return False
+            try:
+                stored = json.loads(params_file.read_text(encoding="utf-8"))
+                if stored != params:
+                    return False
+            except Exception:
+                return False
+        return True
+
+    def status(self, steps: list[Callable[..., Any]]) -> dict[str, bool]:
+        """Return a dict mapping ``fn.__qualname__`` → ``True/False`` indicating
+        whether all cached output files exist for each ``@cacheable`` step.
+        Non-decorated callables in *steps* are silently skipped.
+        """
+        result: dict[str, bool] = {}
+        for fn in steps:
+            info: _CacheInfo | None = getattr(fn, "_cache_info", None)
+            if info is None:
+                continue
+            files = info.get_files(info.step_name)
+            result[fn.__qualname__] = all((self.cache_dir / f).exists() for f in files)
+        return result
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _resolve_return_type(fn: Callable[..., Any]) -> type | None:
+    """Resolve the return-type annotation without calling ``get_type_hints()``.
+
+    ``get_type_hints()`` resolves *all* annotations and raises ``NameError``
+    for ``TYPE_CHECKING``-only imports (e.g. ``Dwi`` in ``csd.py``).  We only
+    need the return annotation, so we evaluate just that string in the
+    function's module namespace.
+    """
+    ann = fn.__annotations__.get("return")
+    if ann is None:
+        return None
+    if not isinstance(ann, str):
+        return ann  # type: ignore[return-value]
+    module = sys.modules.get(fn.__module__)
+    if module is None:
+        return None
+    try:
+        return eval(ann, vars(module))
+    except Exception:
+        return None
+
+
+def _has_cache_protocol(t: Any) -> bool:
+    return (
+        callable(getattr(t, "_cache_files", None))
+        and callable(getattr(t, "_cache_save", None))
+        and callable(getattr(t, "_cache_load", None))
+    )
+
+
+def _extract_scalar_params(
+    fn: Callable[..., Any],
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
+) -> dict[str, Any] | None:
+    """Extract scalar (``int``, ``float``, ``str``, ``bool``, ``None``) arguments
+    from a call for parameter fingerprinting.  Non-scalar args are silently
+    skipped.  Returns ``None`` if no scalar args are present.
+    """
+    try:
+        sig = inspect.signature(fn)
+        bound = sig.bind(*args, **kwargs)
+        bound.apply_defaults()
+    except Exception:
+        return None
+    params = {
+        k: v
+        for k, v in bound.arguments.items()
+        if isinstance(v, (int, float, str, bool, type(None)))
+    }
+    return params or None
+
+
+def _save_params(
+    cache_dir: Path, step_name: str, params: dict[str, Any] | None
+) -> None:
+    if not params:
+        return
+    (cache_dir / f"{step_name}.params.json").write_text(
+        json.dumps(params, sort_keys=True), encoding="utf-8"
+    )
+
+
+def cacheable(fn_or_spec: Callable[..., Any] | CacheSpec[Any]) -> Any:  # type: ignore[return]
+    """Decorator that adds transparent caching when a :class:`PipelineCache`
+    context is active.  Outside a ``with PipelineCache(...)`` block the
+    function runs normally with no caching overhead.
+
+    Two styles:
+
+    - **Bare** ``@cacheable`` — return type must implement the cache protocol
+      (``_cache_files``, ``_cache_save``, ``_cache_load``).
+    - **Explicit spec** ``@cacheable(CacheSpec(...))`` — for return types that
+      cannot carry the protocol (tuples, arrays, etc.).
+
+    Scalar arguments are fingerprinted automatically; a change forces recompute.
+    """
+    if isinstance(fn_or_spec, CacheSpec):
+        spec: CacheSpec[Any] = fn_or_spec
+
+        def _decorator(fn: Callable[..., Any]) -> Callable[..., Any]:
+            step_name = spec.step_name or fn.__name__
+
+            @functools.wraps(fn)
+            def _wrapper(*args: Any, **kwargs: Any) -> Any:
+                cache = _active_cache.get()
+                if cache is None:
+                    return fn(*args, **kwargs)
+                params = _extract_scalar_params(fn, args, kwargs)
+                if cache.is_cached(step_name, spec.files, params):
+                    return spec.load(cache.cache_dir)
+                result = fn(*args, **kwargs)
+                spec.save(result, cache.cache_dir)
+                _save_params(cache.cache_dir, step_name, params)
+                return spec.load(cache.cache_dir)
+
+            _wrapper._cache_info = _CacheInfo(  # type: ignore[attr-defined]
+                step_name=step_name,
+                get_files=lambda _sn: spec.files,
+            )
+            return _wrapper
+
+        return _decorator
+
+    # Bare @cacheable — fn_or_spec is the function itself.
+    # Return-type resolution is deferred to first use so that @cacheable can be
+    # stacked directly on @staticmethod inside a class body, where the class
+    # name isn't yet in the module namespace at decoration time.
+    fn = fn_or_spec
+    step_name = fn.__name__
+    _resolved_type: type | None = None
+
+    def _get_return_type() -> type:
+        nonlocal _resolved_type
+        if _resolved_type is None:
+            rt = _resolve_return_type(fn)
+            if rt is None:
+                msg = f"@cacheable: {fn.__qualname__} has no resolvable return type annotation."
+                raise TypeError(msg)
+            if not _has_cache_protocol(rt):
+                msg = (
+                    f"@cacheable: return type {rt!r} of {fn.__qualname__} does not "
+                    "implement the cache protocol (_cache_files, _cache_save, _cache_load)."
+                )
+                raise TypeError(msg)
+            _resolved_type = rt
+        return _resolved_type
+
+    @functools.wraps(fn)
+    def _wrapper(*args: Any, **kwargs: Any) -> Any:
+        cache = _active_cache.get()
+        if cache is None:
+            return fn(*args, **kwargs)
+        rt = _get_return_type()
+        params = _extract_scalar_params(fn, args, kwargs)
+        files = rt._cache_files(step_name)
+        if cache.is_cached(step_name, files, params):
+            return rt._cache_load(cache.cache_dir, step_name)
+        result = fn(*args, **kwargs)
+        result._cache_save(cache.cache_dir, step_name)
+        _save_params(cache.cache_dir, step_name, params)
+        return rt._cache_load(cache.cache_dir, step_name)
+
+    _wrapper._cache_info = _CacheInfo(  # type: ignore[attr-defined]
+        step_name=step_name,
+        get_files=lambda sn: _get_return_type()._cache_files(sn),
+    )
+    return _wrapper

--- a/src/kwneuro/csd.py
+++ b/src/kwneuro/csd.py
@@ -207,10 +207,10 @@ def compute_csd_fods(
     return coeffs
 
 
-@cacheable(
+@cacheable(  # type: ignore[untyped-decorator]
     CacheSpec(
         files=["csd_peak_dirs.nii.gz", "csd_peak_values.nii.gz"],
-        save=lambda result, d: (
+        save=lambda result, d: (  # type: ignore[arg-type]
             NiftiVolumeResource.save(result[0], d / "csd_peak_dirs.nii.gz"),
             NiftiVolumeResource.save(result[1], d / "csd_peak_values.nii.gz"),
         ),

--- a/src/kwneuro/csd.py
+++ b/src/kwneuro/csd.py
@@ -14,6 +14,8 @@ from dipy.reconst.csdeconv import (
 )
 from dipy.reconst.shm import convert_sh_descoteaux_tournier
 
+from kwneuro.cache import CacheSpec, cacheable
+from kwneuro.io import NiftiVolumeResource
 from kwneuro.resource import (
     InMemoryResponseFunctionResource,
     ResponseFunctionResource,
@@ -84,6 +86,7 @@ def combine_response_functions(
     )
 
 
+@cacheable
 def estimate_response_function(
     dwi: Dwi,
     mask: VolumeResource,
@@ -204,6 +207,19 @@ def compute_csd_fods(
     return coeffs
 
 
+@cacheable(
+    CacheSpec(
+        files=["csd_peak_dirs.nii.gz", "csd_peak_values.nii.gz"],
+        save=lambda result, d: (
+            NiftiVolumeResource.save(result[0], d / "csd_peak_dirs.nii.gz"),
+            NiftiVolumeResource.save(result[1], d / "csd_peak_values.nii.gz"),
+        ),
+        load=lambda d: (
+            NiftiVolumeResource(d / "csd_peak_dirs.nii.gz"),
+            NiftiVolumeResource(d / "csd_peak_values.nii.gz"),
+        ),
+    )
+)
 def compute_csd_peaks(
     dwi: Dwi,
     mask: VolumeResource,
@@ -260,18 +276,18 @@ def compute_csd_peaks(
         npeaks=n_peaks,
     )
 
-    peak_dirs = create_estimate_volume_resource(
-        array=csd_peaks.peak_dirs,
-        reference_volume=dwi.volume,
-        intent_name="CSD_PEAK_DIRS",
+    return (
+        create_estimate_volume_resource(
+            array=csd_peaks.peak_dirs,
+            reference_volume=dwi.volume,
+            intent_name="CSD_PEAK_DIRS",
+        ),
+        create_estimate_volume_resource(
+            array=csd_peaks.peak_values,
+            reference_volume=dwi.volume,
+            intent_name="CSD_PEAK_VALS",
+        ),
     )
-    peak_values = create_estimate_volume_resource(
-        array=csd_peaks.peak_values,
-        reference_volume=dwi.volume,
-        intent_name="CSD_PEAK_VALS",
-    )
-
-    return (peak_dirs, peak_values)
 
 
 def combine_csd_peaks_to_vector_volume(

--- a/src/kwneuro/dti.py
+++ b/src/kwneuro/dti.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 import dipy.reconst.dti
 
+from kwneuro.cache import cacheable
 from kwneuro.io import NiftiVolumeResource
 from kwneuro.resource import InMemoryVolumeResource, VolumeResource
 from kwneuro.util import PathLike, update_volume_metadata
@@ -29,6 +31,22 @@ class Dti:
             volume=self.volume.load(),
         )
 
+    # ------------------------------------------------------------------
+    # Cache protocol
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def _cache_files(cls, step_name: str) -> list[str]:
+        # Fixed name avoids collision with Noddi (same step_name "estimate_from_dwi").
+        return ["dti.nii.gz"]
+
+    def _cache_save(self, cache_dir: Path, step_name: str) -> None:
+        self.save(cache_dir / "dti.nii.gz")
+
+    @classmethod
+    def _cache_load(cls, cache_dir: Path, step_name: str) -> Dti:
+        return cls(NiftiVolumeResource(cache_dir / "dti.nii.gz"))
+
     def save(self, path: PathLike) -> Dti:
         """Save all resources to disk and return a Dti with all resources being on-disk.
 
@@ -42,6 +60,7 @@ class Dti:
         )
 
     @staticmethod
+    @cacheable
     def estimate_from_dwi(dwi: Dwi, mask: VolumeResource | None = None) -> Dti:
         """Estimate a DTI from a DWI.
 

--- a/src/kwneuro/dti.py
+++ b/src/kwneuro/dti.py
@@ -37,15 +37,14 @@ class Dti:
 
     @classmethod
     def _cache_files(cls, step_name: str) -> list[str]:
-        # Fixed name avoids collision with Noddi (same step_name "estimate_from_dwi").
-        return ["dti.nii.gz"]
+        return [f"{step_name}.nii.gz"]
 
     def _cache_save(self, cache_dir: Path, step_name: str) -> None:
-        self.save(cache_dir / "dti.nii.gz")
+        self.save(cache_dir / f"{step_name}.nii.gz")
 
     @classmethod
     def _cache_load(cls, cache_dir: Path, step_name: str) -> Dti:
-        return cls(NiftiVolumeResource(cache_dir / "dti.nii.gz"))
+        return cls(NiftiVolumeResource(cache_dir / f"{step_name}.nii.gz"))
 
     def save(self, path: PathLike) -> Dti:
         """Save all resources to disk and return a Dti with all resources being on-disk.
@@ -61,7 +60,7 @@ class Dti:
 
     @staticmethod
     @cacheable
-    def estimate_from_dwi(dwi: Dwi, mask: VolumeResource | None = None) -> Dti:
+    def estimate_dti(dwi: Dwi, mask: VolumeResource | None = None) -> Dti:
         """Estimate a DTI from a DWI.
 
         Args:

--- a/src/kwneuro/dwi.py
+++ b/src/kwneuro/dwi.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import dipy.core.gradients
 import numpy as np
 
+from kwneuro.cache import cacheable
 from kwneuro.denoise import denoise_dwi
 from kwneuro.dti import Dti
 from kwneuro.io import FslBvalResource, FslBvecResource, NiftiVolumeResource
@@ -59,6 +60,25 @@ class Dwi:
             volume=self.volume.load(),
             bval=self.bval.load(),
             bvec=self.bvec.load(),
+        )
+
+    # ------------------------------------------------------------------
+    # Cache protocol
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def _cache_files(cls, step_name: str) -> list[str]:
+        return [f"{step_name}.nii.gz", f"{step_name}.bval", f"{step_name}.bvec"]
+
+    def _cache_save(self, cache_dir: Path, step_name: str) -> None:
+        self.save(cache_dir, step_name)
+
+    @classmethod
+    def _cache_load(cls, cache_dir: Path, step_name: str) -> Dwi:
+        return cls(
+            NiftiVolumeResource(cache_dir / f"{step_name}.nii.gz"),
+            FslBvalResource(cache_dir / f"{step_name}.bval"),
+            FslBvecResource(cache_dir / f"{step_name}.bvec"),
         )
 
     def save(self, path: PathLike, basename: str) -> Dwi:
@@ -244,3 +264,7 @@ def subsample_dwi(dwi: Dwi, factor: int = 2) -> Dwi:
         bval=dwi.bval,
         bvec=dwi.bvec,
     )
+
+
+Dwi.denoise = cacheable(Dwi.denoise)
+Dwi.extract_brain = cacheable(Dwi.extract_brain)

--- a/src/kwneuro/dwi.py
+++ b/src/kwneuro/dwi.py
@@ -241,7 +241,7 @@ class Dwi:
 
     def estimate_dti(self, mask: VolumeResource | None = None) -> Dti:
         """Estimate diffusion tensor image from this DWI"""
-        return Dti.estimate_from_dwi(self, mask)
+        return Dti.estimate_dti(self, mask)
 
     def estimate_noddi(
         self,
@@ -249,8 +249,8 @@ class Dwi:
         dpar: float = 1.7e-3,
         n_kernel_dirs: int = 500,
     ) -> Noddi:
-        """Estimate NODDI model parameters from this DWI. See :meth:`kwneuro.noddi.Noddi.estimate_from_dwi` for details."""
-        return Noddi.estimate_from_dwi(self, mask, dpar, n_kernel_dirs)
+        """Estimate NODDI model parameters from this DWI. See :meth:`kwneuro.noddi.Noddi.estimate_noddi` for details."""
+        return Noddi.estimate_noddi(self, mask, dpar, n_kernel_dirs)
 
 
 def subsample_dwi(dwi: Dwi, factor: int = 2) -> Dwi:

--- a/src/kwneuro/dwi.py
+++ b/src/kwneuro/dwi.py
@@ -241,7 +241,7 @@ class Dwi:
 
     def estimate_dti(self, mask: VolumeResource | None = None) -> Dti:
         """Estimate diffusion tensor image from this DWI"""
-        return Dti.estimate_dti(self, mask)
+        return Dti.estimate_dti(self, mask)  # type: ignore[no-any-return]
 
     def estimate_noddi(
         self,
@@ -250,7 +250,7 @@ class Dwi:
         n_kernel_dirs: int = 500,
     ) -> Noddi:
         """Estimate NODDI model parameters from this DWI. See :meth:`kwneuro.noddi.Noddi.estimate_noddi` for details."""
-        return Noddi.estimate_noddi(self, mask, dpar, n_kernel_dirs)
+        return Noddi.estimate_noddi(self, mask, dpar, n_kernel_dirs)  # type: ignore[no-any-return]
 
 
 def subsample_dwi(dwi: Dwi, factor: int = 2) -> Dwi:
@@ -266,5 +266,5 @@ def subsample_dwi(dwi: Dwi, factor: int = 2) -> Dwi:
     )
 
 
-Dwi.denoise = cacheable(Dwi.denoise)
-Dwi.extract_brain = cacheable(Dwi.extract_brain)
+Dwi.denoise = cacheable(Dwi.denoise)  # type: ignore[method-assign]
+Dwi.extract_brain = cacheable(Dwi.extract_brain)  # type: ignore[method-assign]

--- a/src/kwneuro/noddi.py
+++ b/src/kwneuro/noddi.py
@@ -44,17 +44,19 @@ class Noddi:
 
     @classmethod
     def _cache_files(cls, step_name: str) -> list[str]:
-        return ["noddi.nii.gz", "noddi_directions.nii.gz"]
+        return [f"{step_name}.nii.gz", f"{step_name}_directions.nii.gz"]
 
     def _cache_save(self, cache_dir: Path, step_name: str) -> None:
-        NiftiVolumeResource.save(self.volume, cache_dir / "noddi.nii.gz")
-        NiftiVolumeResource.save(self.directions, cache_dir / "noddi_directions.nii.gz")
+        NiftiVolumeResource.save(self.volume, cache_dir / f"{step_name}.nii.gz")
+        NiftiVolumeResource.save(
+            self.directions, cache_dir / f"{step_name}_directions.nii.gz"
+        )
 
     @classmethod
     def _cache_load(cls, cache_dir: Path, step_name: str) -> Noddi:
         return cls(
-            NiftiVolumeResource(cache_dir / "noddi.nii.gz"),
-            NiftiVolumeResource(cache_dir / "noddi_directions.nii.gz"),
+            NiftiVolumeResource(cache_dir / f"{step_name}.nii.gz"),
+            NiftiVolumeResource(cache_dir / f"{step_name}_directions.nii.gz"),
         )
 
     def save(self, path: PathLike) -> Noddi:
@@ -78,7 +80,7 @@ class Noddi:
 
     @staticmethod
     @cacheable
-    def estimate_from_dwi(
+    def estimate_noddi(
         dwi: Dwi,
         mask: VolumeResource | None = None,
         dpar: float = 1.7e-3,

--- a/src/kwneuro/noddi.py
+++ b/src/kwneuro/noddi.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from kwneuro.cache import cacheable
 from kwneuro.io import FslBvalResource, FslBvecResource, NiftiVolumeResource
 from kwneuro.resource import InMemoryVolumeResource, VolumeResource
 from kwneuro.util import (
@@ -37,6 +38,25 @@ class Noddi:
         """Load any on-disk resources into memory and return a DTI with all loadable resources loaded."""
         return Noddi(volume=self.volume.load(), directions=self.directions.load())
 
+    # ------------------------------------------------------------------
+    # Cache protocol
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def _cache_files(cls, step_name: str) -> list[str]:
+        return ["noddi.nii.gz", "noddi_directions.nii.gz"]
+
+    def _cache_save(self, cache_dir: Path, step_name: str) -> None:
+        NiftiVolumeResource.save(self.volume, cache_dir / "noddi.nii.gz")
+        NiftiVolumeResource.save(self.directions, cache_dir / "noddi_directions.nii.gz")
+
+    @classmethod
+    def _cache_load(cls, cache_dir: Path, step_name: str) -> Noddi:
+        return cls(
+            NiftiVolumeResource(cache_dir / "noddi.nii.gz"),
+            NiftiVolumeResource(cache_dir / "noddi_directions.nii.gz"),
+        )
+
     def save(self, path: PathLike) -> Noddi:
         """Save all resources to disk and return a Noddi with all resources being on-disk.
 
@@ -57,6 +77,7 @@ class Noddi:
         )
 
     @staticmethod
+    @cacheable
     def estimate_from_dwi(
         dwi: Dwi,
         mask: VolumeResource | None = None,

--- a/src/kwneuro/resource.py
+++ b/src/kwneuro/resource.py
@@ -2,7 +2,11 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from typing import Any, ClassVar
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, ClassVar
+
+if TYPE_CHECKING:
+    from kwneuro.io import JsonResponseFunctionResource, NiftiVolumeResource
 
 import ants
 import nibabel as nib
@@ -50,6 +54,26 @@ class VolumeResource(Resource):
     @abstractmethod
     def load(self) -> InMemoryVolumeResource:
         """Load volume into memory"""
+
+    # ------------------------------------------------------------------
+    # Cache protocol — used by @cacheable when the return type is a
+    # VolumeResource subclass.  Subclasses may override for custom names.
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def _cache_files(cls, step_name: str) -> list[str]:
+        return [f"{step_name}.nii.gz"]
+
+    def _cache_save(self, cache_dir: Path, step_name: str) -> None:
+        from kwneuro.io import NiftiVolumeResource
+
+        NiftiVolumeResource.save(self, cache_dir / f"{step_name}.nii.gz")
+
+    @classmethod
+    def _cache_load(cls, cache_dir: Path, step_name: str) -> NiftiVolumeResource:
+        from kwneuro.io import NiftiVolumeResource
+
+        return NiftiVolumeResource(cache_dir / f"{step_name}.nii.gz")
 
 
 @dataclass
@@ -284,3 +308,24 @@ class InMemoryResponseFunctionResource(ResponseFunctionResource):
         """Return the stored response function as a DIPY `AxSymShResponse`."""
 
         return AxSymShResponse(S0=self.avg_signal, dwi_response=self.sh_coeffs)
+
+    # ------------------------------------------------------------------
+    # Cache protocol
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def _cache_files(cls, step_name: str) -> list[str]:
+        return [f"{step_name}.json"]
+
+    def _cache_save(self, cache_dir: Path, step_name: str) -> None:
+        from kwneuro.io import JsonResponseFunctionResource
+
+        JsonResponseFunctionResource.save(self, cache_dir / f"{step_name}.json")
+
+    @classmethod
+    def _cache_load(
+        cls, cache_dir: Path, step_name: str
+    ) -> JsonResponseFunctionResource:
+        from kwneuro.io import JsonResponseFunctionResource
+
+        return JsonResponseFunctionResource(cache_dir / f"{step_name}.json")

--- a/src/kwneuro/tractseg.py
+++ b/src/kwneuro/tractseg.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
+from kwneuro.cache import _active_cache
 from kwneuro.csd import combine_csd_peaks_to_vector_volume, compute_csd_peaks
+from kwneuro.io import NiftiVolumeResource
 from kwneuro.resource import ResponseFunctionResource, VolumeResource
 from kwneuro.util import create_estimate_volume_resource
 
@@ -31,44 +33,63 @@ def extract_tractseg(
     mask: VolumeResource,
     response: ResponseFunctionResource | None = None,
     output_type: str = "tract_segmentation",
+    csd_peaks: tuple[VolumeResource, VolumeResource] | None = None,
 ) -> VolumeResource:
     """Run TractSeg on a DWI dataset to segment white matter tracts.
 
     Args:
         dwi: The Diffusion Weighted Imaging (DWI) dataset.
         mask: A binary brain mask volume.
-        response (Optional): The single-fiber response function. If `None`, the response function is estimated using an ROI in the center of the brain mask.
+        response (Optional): The single-fiber response function. If `None`, the
+            response function is estimated automatically. Ignored when
+            ``csd_peaks`` is provided.
         output_type: TractSeg can segment not only bundles, but also the end regions of bundles.
             Moreover it can create Tract Orientation Maps (TOM).
             'tract_segmentation' [DEFAULT]: Segmentation of bundles (72 bundles).
             'endings_segmentation': Segmentation of bundle end regions (72 bundles).
             'TOM': Tract Orientation Maps (20 bundles).
+        csd_peaks (Optional): Pre-computed CSD peaks as a ``(directions, values)`` tuple
+            of VolumeResources. When provided the CSD computation step is skipped.
 
     Returns: A volume resource containing a 4D numpy array with the output of tractseg
         for tract_segmentation:     [x, y, z, nr_of_bundles]
         for endings_segmentation:   [x, y, z, 2*nr_of_bundles]
         for TOM:                    [x, y, z, 3*nr_of_bundles]
     """
+    # Inline cache check — uses a dynamic filename so a decorator cannot be used.
+    _cache = _active_cache.get()
+    _cache_file = f"tractseg_{output_type}.nii.gz"
+    if _cache is not None and _cache.is_cached("extract_tractseg", [_cache_file]):
+        logging.info("extract_tractseg: cache hit (%s)", output_type)
+        return NiftiVolumeResource(_cache.cache_dir / _cache_file)
 
-    # Compute CSD peaks
-    csd_peaks = compute_csd_peaks(
-        dwi,
-        mask,
-        response=response,
-        flip_bvecs_x=True,
-        n_peaks=3,  # MRtrix3 uses 3 peaks
-    )
+    if csd_peaks is None:
+        # Compute CSD peaks (MRtrix3 convention: 3 peaks).
+        # compute_csd_peaks is @cacheable, so it uses _cache automatically.
+        csd_peaks = compute_csd_peaks(
+            dwi,
+            mask,
+            response=response,
+            flip_bvecs_x=True,
+            n_peaks=3,
+        )
+
     csd_peaks_vector = combine_csd_peaks_to_vector_volume(
         csd_peaks_dirs=csd_peaks[0], csd_peaks_values=csd_peaks[1]
     )
-    # Run TractSeg
     logging.info("Running tractseg...")
     segmentation = _call_tractseg(
         data=csd_peaks_vector.get_array(), output_type=output_type
     )
 
-    return create_estimate_volume_resource(
+    result = create_estimate_volume_resource(
         array=segmentation,
         reference_volume=dwi.volume,
         intent_name="TRACTSEG",
     )
+
+    if _cache is not None:
+        logging.info("extract_tractseg: saving cache (%s)", output_type)
+        return NiftiVolumeResource.save(result, _cache.cache_dir / _cache_file)
+
+    return result

--- a/src/kwneuro/tractseg.py
+++ b/src/kwneuro/tractseg.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
-from kwneuro.cache import _active_cache
+from kwneuro.cache import _active_cache, _compute_fingerprint, _save_params
 from kwneuro.csd import combine_csd_peaks_to_vector_volume, compute_csd_peaks
 from kwneuro.io import NiftiVolumeResource
 from kwneuro.resource import ResponseFunctionResource, VolumeResource
@@ -59,9 +59,24 @@ def extract_tractseg(
     # Inline cache check — uses a dynamic filename so a decorator cannot be used.
     _cache = _active_cache.get()
     _cache_file = f"tractseg_{output_type}.nii.gz"
-    if _cache is not None and _cache.is_cached("extract_tractseg", [_cache_file]):
-        logging.info("extract_tractseg: cache hit (%s)", output_type)
-        return NiftiVolumeResource(_cache.cache_dir / _cache_file)
+    _scalars: dict[str, Any] | None = None
+    _hashes: dict[str, str] | None = None
+    if _cache is not None:
+        _scalars = {"output_type": output_type}
+        h: dict[str, str] = {}
+        for name, val in [
+            ("dwi", dwi),
+            ("mask", mask),
+            ("response", response),
+            ("csd_peaks", csd_peaks),
+        ]:
+            fp = _compute_fingerprint(val)
+            if fp is not None:
+                h[name] = fp
+        _hashes = h or None
+        if _cache.is_cached("extract_tractseg", [_cache_file], _scalars, _hashes):
+            logging.info("extract_tractseg: cache hit (%s)", output_type)
+            return NiftiVolumeResource(_cache.cache_dir / _cache_file)
 
     if csd_peaks is None:
         # Compute CSD peaks (MRtrix3 convention: 3 peaks).
@@ -90,6 +105,7 @@ def extract_tractseg(
 
     if _cache is not None:
         logging.info("extract_tractseg: saving cache (%s)", output_type)
+        _save_params(_cache.cache_dir, "extract_tractseg", _scalars, _hashes)
         return NiftiVolumeResource.save(result, _cache.cache_dir / _cache_file)
 
     return result

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -13,6 +13,7 @@ from kwneuro.cache import (
     Cache,
     CacheSpec,
     _active_cache,
+    _compute_fingerprint,
     cacheable,
 )
 from kwneuro.csd import compute_csd_peaks
@@ -536,3 +537,134 @@ def test_untracked_param_warns(tmp_path: Path) -> None:
 
     with pytest.warns(UserWarning, match="cannot be fingerprinted"), Cache(tmp_path):
         fn(Opaque())
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for _compute_fingerprint
+# ---------------------------------------------------------------------------
+
+
+def test_fingerprint_stability(random_affine: np.ndarray) -> None:
+    """Same VolumeResource produces the same fingerprint on repeated calls."""
+    vol = InMemoryVolumeResource(
+        array=np.ones((3, 4, 5), dtype=np.float32),
+        affine=random_affine,
+    )
+    fp1 = _compute_fingerprint(vol)
+    fp2 = _compute_fingerprint(vol)
+    assert fp1 is not None
+    assert len(fp1) == 64  # sha256 hex digest
+    assert fp1 == fp2
+
+
+def test_fingerprint_volume_resource_array_change(random_affine: np.ndarray) -> None:
+    """Changing the array field of a VolumeResource changes its fingerprint."""
+    vol_a = InMemoryVolumeResource(
+        array=np.ones((3, 4, 5), dtype=np.float32),
+        affine=random_affine,
+    )
+    vol_b = InMemoryVolumeResource(
+        array=np.zeros((3, 4, 5), dtype=np.float32),
+        affine=random_affine,
+    )
+    assert _compute_fingerprint(vol_a) != _compute_fingerprint(vol_b)
+
+
+def test_fingerprint_volume_resource_affine_change() -> None:
+    """Changing the affine of a VolumeResource changes its fingerprint."""
+    arr = np.ones((3, 4, 5), dtype=np.float32)
+    vol_a = InMemoryVolumeResource(array=arr, affine=np.eye(4))
+    vol_b = InMemoryVolumeResource(array=arr, affine=2 * np.eye(4))
+    assert _compute_fingerprint(vol_a) != _compute_fingerprint(vol_b)
+
+
+def test_fingerprint_ndarray_shape_matters() -> None:
+    """Arrays with the same bytes but different shapes produce different fingerprints."""
+    flat = np.arange(6, dtype=np.float32)
+    reshaped = flat.reshape(2, 3).copy()
+    assert _compute_fingerprint(flat) != _compute_fingerprint(reshaped)
+
+
+def test_fingerprint_ndarray_dtype_matters() -> None:
+    """Arrays with the same values but different dtypes produce different fingerprints."""
+    a_int = np.array([1, 2, 3], dtype=np.int32)
+    a_float = np.array([1, 2, 3], dtype=np.float32)
+    assert _compute_fingerprint(a_int) != _compute_fingerprint(a_float)
+
+
+def test_fingerprint_nested_dataclass(
+    random_affine: np.ndarray, small_nifti_header: nib.Nifti1Header
+) -> None:
+    """Changing a nested field (bvec) inside a Dwi propagates to a different Dwi fingerprint."""
+    n_vols = 4
+    rng = np.random.default_rng(999)
+    bvecs = rng.random(size=(n_vols, 3), dtype=np.float32)
+    bvecs = bvecs / np.sqrt((bvecs**2).sum(axis=1, keepdims=True))
+    dwi_a = Dwi(
+        volume=InMemoryVolumeResource(
+            array=rng.random(size=(3, 4, 5, n_vols), dtype=np.float32),
+            affine=random_affine,
+            metadata=dict(small_nifti_header),
+        ),
+        bval=InMemoryBvalResource(array=np.array([0, 1000, 2000, 0], dtype=float)),
+        bvec=InMemoryBvecResource(array=bvecs),
+    )
+    # Same everything except bvec
+    different_bvecs = rng.random(size=(n_vols, 3), dtype=np.float32)
+    different_bvecs = different_bvecs / np.sqrt(
+        (different_bvecs**2).sum(axis=1, keepdims=True)
+    )
+    dwi_b = Dwi(
+        volume=dwi_a.volume,
+        bval=dwi_a.bval,
+        bvec=InMemoryBvecResource(array=different_bvecs),
+    )
+    assert _compute_fingerprint(dwi_a) != _compute_fingerprint(dwi_b)
+
+
+def test_fingerprint_path() -> None:
+    """Different Paths produce different fingerprints; same Path is stable."""
+    fp_a = _compute_fingerprint(Path("/a/b"))
+    fp_b = _compute_fingerprint(Path("/a/c"))
+    assert fp_a is not None
+    assert fp_a != fp_b
+    assert fp_a == _compute_fingerprint(Path("/a/b"))
+
+
+def test_fingerprint_unrecognized_type_returns_none() -> None:
+    """An unrecognized type returns None (caller should warn)."""
+    assert _compute_fingerprint(object()) is None
+
+
+# ---------------------------------------------------------------------------
+# Integration: cache invalidation via VolumeResource parameter changes
+# ---------------------------------------------------------------------------
+
+
+def test_cacheable_mask_change_triggers_recompute(
+    dwi3: Dwi, tmp_path: Path, mocker
+) -> None:
+    """Changing a VolumeResource mask parameter invalidates the cache."""
+    mask_a = InMemoryVolumeResource(
+        array=np.ones((3, 4, 5), dtype=np.float32),
+        affine=dwi3.volume.get_affine(),
+    )
+    pc = Cache(tmp_path)
+    with pc:
+        dwi3.estimate_dti(mask=mask_a)
+
+    save_spy = mocker.spy(Dti, "_cache_save")
+
+    # Same mask → cache hit, no recompute
+    with pc:
+        dwi3.estimate_dti(mask=mask_a)
+    save_spy.assert_not_called()
+
+    # Different mask → cache miss, recompute
+    mask_b = InMemoryVolumeResource(
+        array=np.zeros((3, 4, 5), dtype=np.float32),
+        affine=dwi3.volume.get_affine(),
+    )
+    with pc:
+        dwi3.estimate_dti(mask=mask_b)
+    save_spy.assert_called_once()

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -214,8 +214,8 @@ def test_cacheable_raises_on_missing_protocol(tmp_path: Path) -> None:
 
 def test_cacheable_preserves_function_name() -> None:
     """@cacheable preserves __name__ on the wrapped function."""
-    assert Dti.estimate_from_dwi.__name__ == "estimate_from_dwi"
-    assert Noddi.estimate_from_dwi.__name__ == "estimate_from_dwi"
+    assert Dti.estimate_dti.__name__ == "estimate_dti"
+    assert Noddi.estimate_noddi.__name__ == "estimate_noddi"
     assert Dwi.denoise.__name__ == "denoise"
 
 
@@ -232,16 +232,16 @@ def test_cacheable_no_op_outside_context(dwi3: Dwi) -> None:
 
 def test_status_missing_shows_false(tmp_path: Path) -> None:
     pc = PipelineCache(tmp_path)
-    result = pc.status([Dti.estimate_from_dwi])
-    assert result["Dti.estimate_from_dwi"] is False
+    result = pc.status([Dti.estimate_dti])
+    assert result["Dti.estimate_dti"] is False
 
 
 def test_status_present_shows_true(dwi3: Dwi, tmp_path: Path) -> None:
     pc = PipelineCache(tmp_path)
     with pc:
         dwi3.estimate_dti()
-    result = pc.status([Dti.estimate_from_dwi])
-    assert result["Dti.estimate_from_dwi"] is True
+    result = pc.status([Dti.estimate_dti])
+    assert result["Dti.estimate_dti"] is True
 
 
 def test_status_non_cacheable_skipped(tmp_path: Path) -> None:
@@ -257,9 +257,9 @@ def test_status_multiple_steps(dwi3: Dwi, tmp_path: Path) -> None:
     pc = PipelineCache(tmp_path)
     with pc:
         dwi3.estimate_dti()
-    result = pc.status([Dti.estimate_from_dwi, Noddi.estimate_from_dwi])
-    assert result["Dti.estimate_from_dwi"] is True
-    assert result["Noddi.estimate_from_dwi"] is False
+    result = pc.status([Dti.estimate_dti, Noddi.estimate_noddi])
+    assert result["Dti.estimate_dti"] is True
+    assert result["Noddi.estimate_noddi"] is False
 
 
 # ---------------------------------------------------------------------------
@@ -275,8 +275,8 @@ def test_estimate_dti_with_caching(dwi3: Dwi, tmp_path: Path) -> None:
 
     assert np.allclose(dti.volume.get_affine(), dwi3.volume.get_affine())
     assert dti.volume.get_array().shape[:3] == (3, 4, 5)
-    assert (tmp_path / "dti.nii.gz").exists()
-    assert pc.status([Dti.estimate_from_dwi])["Dti.estimate_from_dwi"] is True
+    assert (tmp_path / "estimate_dti.nii.gz").exists()
+    assert pc.status([Dti.estimate_dti])["Dti.estimate_dti"] is True
 
     # Second call returns the same result loaded from cache
     with pc:
@@ -285,22 +285,22 @@ def test_estimate_dti_with_caching(dwi3: Dwi, tmp_path: Path) -> None:
 
 
 def test_estimate_dti_force_recompute(dwi3: Dwi, tmp_path: Path, mocker) -> None:
-    """force={"estimate_from_dwi"} causes DTI to recompute even when a cache exists."""
+    """force={"estimate_dti"} causes DTI to recompute even when a cache exists."""
     pc = PipelineCache(tmp_path)
     with pc:
         dwi3.estimate_dti()
 
     save_spy = mocker.spy(Dti, "_cache_save")
-    with PipelineCache(tmp_path, force={"estimate_from_dwi"}):
+    with PipelineCache(tmp_path, force={"estimate_dti"}):
         dwi3.estimate_dti()
 
     save_spy.assert_called_once()
 
 
 def _make_amico_mock(mocker, rng: np.random.Generator) -> MagicMock:
-    """Patch AMICO internals so Noddi.estimate_from_dwi runs without the full AMICO stack.
+    """Patch AMICO internals so Noddi.estimate_noddi runs without the full AMICO stack.
 
-    The @cacheable wrapper on estimate_from_dwi is left intact so that caching
+    The @cacheable wrapper on estimate_noddi is left intact so that caching
     behaviour can be tested end-to-end.
     """
     mock_ae = MagicMock()
@@ -326,9 +326,9 @@ def test_estimate_noddi_with_caching(dwi3: Dwi, mocker, tmp_path: Path) -> None:
     assert np.allclose(noddi.volume.get_array(), mock_ae.RESULTS["MAPs"])
     assert np.allclose(noddi.directions.get_array(), mock_ae.RESULTS["DIRs"])
     assert np.allclose(noddi.volume.get_affine(), dwi3.volume.get_affine())
-    assert (tmp_path / "noddi.nii.gz").exists()
-    assert (tmp_path / "noddi_directions.nii.gz").exists()
-    assert pc.status([Noddi.estimate_from_dwi])["Noddi.estimate_from_dwi"] is True
+    assert (tmp_path / "estimate_noddi.nii.gz").exists()
+    assert (tmp_path / "estimate_noddi_directions.nii.gz").exists()
+    assert pc.status([Noddi.estimate_noddi])["Noddi.estimate_noddi"] is True
 
     # Second call loads from cache — AMICO fit is not re-invoked
     mock_ae.fit.reset_mock()

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,0 +1,345 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from kwneuro.cache import (
+    CacheSpec,
+    PipelineCache,
+    _active_cache,
+    cacheable,
+)
+
+
+class FakeResource:
+    """Minimal in-memory resource with a cache protocol."""
+
+    def __init__(self, value: int) -> None:
+        self.value = value
+
+    @classmethod
+    def _cache_files(cls, step_name: str) -> list[str]:
+        return [f"{step_name}.fake"]
+
+    def _cache_save(self, cache_dir: Path, step_name: str) -> None:
+        (cache_dir / f"{step_name}.fake").write_text(str(self.value))
+
+    @classmethod
+    def _cache_load(cls, cache_dir: Path, step_name: str) -> FakeResource:
+        val = int((cache_dir / f"{step_name}.fake").read_text())
+        return cls(val)
+
+
+class NoCacheProtocol:
+    """Stub without a cache protocol — should trigger TypeError."""
+
+
+# Exmaple cacheable function
+@cacheable
+def compute_fake(x: int, multiplier: int = 2) -> FakeResource:
+    return FakeResource(x * multiplier)
+
+
+class TestIsForced:
+    def test_false(self, tmp_path: Path) -> None:
+        pc = PipelineCache(tmp_path, force=False)
+        assert not pc.is_forced("any_step")
+
+    def test_true(self, tmp_path: Path) -> None:
+        pc = PipelineCache(tmp_path, force=True)
+        assert pc.is_forced("any_step")
+
+    def test_set_match(self, tmp_path: Path) -> None:
+        pc = PipelineCache(tmp_path, force={"step_a"})
+        assert pc.is_forced("step_a")
+
+    def test_set_no_match(self, tmp_path: Path) -> None:
+        pc = PipelineCache(tmp_path, force={"step_b"})
+        assert not pc.is_forced("step_a")
+
+
+# ---------------------------------------------------------------------------
+# PipelineCache.is_cached
+# ---------------------------------------------------------------------------
+
+
+class TestIsCached:
+    def test_missing_file(self, tmp_path: Path) -> None:
+        pc = PipelineCache(tmp_path)
+        assert not pc.is_cached("step", ["missing.txt"])
+
+    def test_all_files_present(self, tmp_path: Path) -> None:
+        (tmp_path / "out.txt").write_text("x")
+        pc = PipelineCache(tmp_path, force=False)
+        assert pc.is_cached("step", ["out.txt"])
+
+    def test_forced_overrides_present(self, tmp_path: Path) -> None:
+        (tmp_path / "out.txt").write_text("x")
+        pc = PipelineCache(tmp_path, force=True)
+        assert not pc.is_cached("step", ["out.txt"])
+
+    def test_params_match(self, tmp_path: Path) -> None:
+        (tmp_path / "out.txt").write_text("x")
+        import json
+
+        (tmp_path / "step.params.json").write_text(json.dumps({"x": 1}, sort_keys=True))
+        pc = PipelineCache(tmp_path)
+        assert pc.is_cached("step", ["out.txt"], params={"x": 1})
+
+    def test_params_mismatch(self, tmp_path: Path) -> None:
+        (tmp_path / "out.txt").write_text("x")
+        import json
+
+        (tmp_path / "step.params.json").write_text(json.dumps({"x": 1}, sort_keys=True))
+        pc = PipelineCache(tmp_path)
+        assert not pc.is_cached("step", ["out.txt"], params={"x": 99})
+
+    def test_params_file_missing_is_miss(self, tmp_path: Path) -> None:
+        (tmp_path / "out.txt").write_text("x")
+        pc = PipelineCache(tmp_path)
+        assert not pc.is_cached("step", ["out.txt"], params={"x": 1})
+
+
+# ---------------------------------------------------------------------------
+# Context manager
+# ---------------------------------------------------------------------------
+
+
+class TestContextManager:
+    def test_sets_active_cache(self, tmp_path: Path) -> None:
+        assert _active_cache.get() is None
+        pc = PipelineCache(tmp_path)
+        with pc:
+            assert _active_cache.get() is pc
+        assert _active_cache.get() is None
+
+    def test_restores_on_exception(self, tmp_path: Path) -> None:
+        pc = PipelineCache(tmp_path)
+        try:
+            with pc:
+                raise RuntimeError("boom")
+        except RuntimeError:
+            pass
+        assert _active_cache.get() is None
+
+    def test_creates_cache_dir(self, tmp_path: Path) -> None:
+        cache_dir = tmp_path / "nested" / "cache"
+        assert not cache_dir.exists()
+        with PipelineCache(cache_dir):
+            assert cache_dir.is_dir()
+
+
+# ---------------------------------------------------------------------------
+# @cacheable (bare, auto-spec)
+# ---------------------------------------------------------------------------
+
+
+class TestCacheable:
+    def test_cache_miss_calls_function(self, tmp_path: Path) -> None:
+        calls: list[int] = []
+
+        @cacheable
+        def fn(x: int) -> FakeResource:
+            calls.append(x)
+            return FakeResource(x * 3)
+
+        with PipelineCache(tmp_path):
+            result = fn(4)
+
+        assert calls == [4]
+        assert result.value == 12
+
+    def test_cache_hit_skips_function(self, tmp_path: Path) -> None:
+        calls: list[int] = []
+
+        @cacheable
+        def fn(x: int) -> FakeResource:
+            calls.append(x)
+            return FakeResource(x * 3)
+
+        pc = PipelineCache(tmp_path)
+        with pc:
+            fn(4)  # populate cache
+        calls.clear()
+        with pc:
+            result = fn(99)  # different arg — cache hit returns saved value
+
+        assert calls == []  # function not called
+        assert result.value == 12  # loaded from cache (original value)
+
+    def test_outside_context_no_caching(self) -> None:
+        calls: list[int] = []
+
+        @cacheable
+        def fn(x: int) -> FakeResource:
+            calls.append(x)
+            return FakeResource(x)
+
+        result = fn(7)
+        assert calls == [7]
+        assert result.value == 7  # returned directly, not from disk
+
+    def test_parameter_change_triggers_recompute(self, tmp_path: Path) -> None:
+        calls: list[int] = []
+
+        @cacheable
+        def fn(x: int, multiplier: int = 2) -> FakeResource:
+            calls.append(multiplier)
+            return FakeResource(x * multiplier)
+
+        pc = PipelineCache(tmp_path)
+        with pc:
+            fn(5, multiplier=2)
+        calls.clear()
+        with pc:
+            result = fn(5, multiplier=10)  # changed scalar param → recompute
+
+        assert calls == [10]
+        assert result.value == 50
+
+    def test_same_params_no_recompute(self, tmp_path: Path) -> None:
+        calls: list[int] = []
+
+        @cacheable
+        def fn(x: int, multiplier: int = 2) -> FakeResource:
+            calls.append(multiplier)
+            return FakeResource(x * multiplier)
+
+        pc = PipelineCache(tmp_path)
+        with pc:
+            fn(5, multiplier=2)
+        calls.clear()
+        with pc:
+            fn(5, multiplier=2)  # same params → cache hit
+
+        assert calls == []
+
+    def test_type_error_on_no_return_annotation(self) -> None:
+        with pytest.raises(TypeError, match="no resolvable return type"):
+
+            @cacheable
+            def bad_fn(x: int):
+                return FakeResource(x)
+
+    def test_type_error_on_missing_protocol(self) -> None:
+        with pytest.raises(TypeError, match="does not implement the cache protocol"):
+
+            @cacheable
+            def bad_fn(x: int) -> NoCacheProtocol:
+                return NoCacheProtocol()
+
+    def test_functools_wraps_preserved(self) -> None:
+        assert compute_fake.__name__ == "compute_fake"
+
+    def test_force_step_bypasses_cache(self, tmp_path: Path) -> None:
+        calls: list[int] = []
+
+        @cacheable
+        def fn(x: int) -> FakeResource:
+            calls.append(x)
+            return FakeResource(x)
+
+        pc = PipelineCache(tmp_path)
+        with pc:
+            fn(1)
+        calls.clear()
+        with PipelineCache(tmp_path, force={"fn"}):
+            fn(1)
+
+        assert calls == [1]  # forced recompute
+
+
+# ---------------------------------------------------------------------------
+# @cacheable(CacheSpec(...)) — explicit spec
+# ---------------------------------------------------------------------------
+class TestCacheSpec:
+    def test_explicit_spec_miss_and_hit(self, tmp_path: Path) -> None:
+        calls: list[str] = []
+
+        @cacheable(
+            CacheSpec(
+                files=["result.txt"],
+                save=lambda val, d: (d / "result.txt").write_text(val),
+                load=lambda d: (d / "result.txt").read_text(),
+            )
+        )
+        def fn(label: str) -> str:
+            calls.append(label)
+            return label.upper()
+
+        pc = PipelineCache(tmp_path)
+        with pc:
+            r1 = fn("hello")
+        assert r1 == "HELLO"
+        assert calls == ["hello"]
+
+        calls.clear()
+        with pc:
+            r2 = fn("world")  # cache hit — returns previously saved value
+        assert r2 == "HELLO"
+        assert calls == []
+
+    def test_explicit_spec_param_change(self, tmp_path: Path) -> None:
+        calls: list[str] = []
+
+        @cacheable(
+            CacheSpec(
+                files=["result.txt"],
+                save=lambda val, d: (d / "result.txt").write_text(val),
+                load=lambda d: (d / "result.txt").read_text(),
+            )
+        )
+        def fn(label: str) -> str:
+            calls.append(label)
+            return label.upper()
+
+        pc = PipelineCache(tmp_path)
+        with pc:
+            fn("hello")
+        calls.clear()
+        with pc:
+            r = fn("goodbye")  # scalar param changed → recompute
+
+        assert calls == ["goodbye"]
+        assert r == "GOODBYE"
+
+
+# ---------------------------------------------------------------------------
+# PipelineCache.status
+# ---------------------------------------------------------------------------
+class TestStatus:
+    def test_missing_shows_false(self, tmp_path: Path) -> None:
+        pc = PipelineCache(tmp_path)
+        result = pc.status([compute_fake])
+        assert result["compute_fake"] is False
+
+    def test_present_shows_true(self, tmp_path: Path) -> None:
+        pc = PipelineCache(tmp_path)
+        with pc:
+            compute_fake(3)
+        result = pc.status([compute_fake])
+        assert result["compute_fake"] is True
+
+    def test_non_cacheable_skipped(self, tmp_path: Path) -> None:
+        def plain() -> None:
+            pass
+
+        pc = PipelineCache(tmp_path)
+        assert pc.status([plain]) == {}
+
+    def test_multiple_steps(self, tmp_path: Path) -> None:
+        @cacheable
+        def step_a(x: int) -> FakeResource:
+            return FakeResource(x)
+
+        @cacheable
+        def step_b(x: int) -> FakeResource:
+            return FakeResource(x)
+
+        pc = PipelineCache(tmp_path)
+        with pc:
+            step_a(1)
+        result = pc.status([step_a, step_b])
+        assert result["step_a"] is True
+        assert result["step_b"] is False

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,62 +1,105 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
+from unittest.mock import MagicMock
 
+import nibabel as nib
+import numpy as np
 import pytest
+from scipy.linalg import expm
 
 from kwneuro.cache import (
-    CacheSpec,
     PipelineCache,
     _active_cache,
     cacheable,
 )
+from kwneuro.csd import compute_csd_peaks
+from kwneuro.dti import Dti
+from kwneuro.dwi import Dwi
+from kwneuro.noddi import Noddi
+from kwneuro.resource import (
+    InMemoryBvalResource,
+    InMemoryBvecResource,
+    InMemoryVolumeResource,
+)
 
 
-class FakeResource:
-    """Minimal in-memory resource with a cache protocol."""
-
-    def __init__(self, value: int) -> None:
-        self.value = value
-
-    @classmethod
-    def _cache_files(cls, step_name: str) -> list[str]:
-        return [f"{step_name}.fake"]
-
-    def _cache_save(self, cache_dir: Path, step_name: str) -> None:
-        (cache_dir / f"{step_name}.fake").write_text(str(self.value))
-
-    @classmethod
-    def _cache_load(cls, cache_dir: Path, step_name: str) -> FakeResource:
-        val = int((cache_dir / f"{step_name}.fake").read_text())
-        return cls(val)
+@pytest.fixture
+def random_affine() -> np.ndarray:
+    rng = np.random.default_rng(18653)
+    affine = np.eye(4)
+    affine[:3, :3] = expm((lambda A: (A - A.T) / 2)(rng.normal(size=(3, 3))))
+    affine[:3, 3] = rng.random(3)
+    return affine
 
 
-class NoCacheProtocol:
-    """Stub without a cache protocol — should trigger TypeError."""
+@pytest.fixture
+def small_nifti_header():
+    hdr = nib.Nifti1Header()
+    hdr["descrip"] = b"an kwneuro unit test header description"
+    return hdr
 
 
-# Exmaple cacheable function
-@cacheable
-def compute_fake(x: int, multiplier: int = 2) -> FakeResource:
-    return FakeResource(x * multiplier)
+@pytest.fixture
+def dwi3(random_affine, small_nifti_header) -> Dwi:
+    """An example in-memory Dwi with 6 volumes, 3 of which have b=0"""
+    n_vols = 6
+    rng = np.random.default_rng(7816)
+    bvec_array = rng.random(size=(n_vols, 3), dtype=np.float32)
+    bvec_array = bvec_array / np.sqrt((bvec_array**2).sum(axis=1, keepdims=True))
+    return Dwi(
+        volume=InMemoryVolumeResource(
+            array=rng.random(size=(3, 4, 5, n_vols), dtype=np.float32),
+            affine=random_affine,
+            metadata=dict(small_nifti_header),
+        ),
+        bval=InMemoryBvalResource(array=np.array([0, 1000, 3000, 0, 0, 2000])),
+        bvec=InMemoryBvecResource(array=bvec_array),
+    )
 
 
-class TestIsForced:
-    def test_false(self, tmp_path: Path) -> None:
-        pc = PipelineCache(tmp_path, force=False)
-        assert not pc.is_forced("any_step")
+@pytest.fixture
+def dwi4(random_affine, small_nifti_header) -> Dwi:
+    """An example in-memory Dwi with 10 volumes."""
+    n_vols = 10
+    rng = np.random.default_rng(4616)
+    bvec_array = rng.random(size=(n_vols, 3), dtype=np.float32)
+    bvec_array = bvec_array / np.sqrt((bvec_array**2).sum(axis=1, keepdims=True))
+    return Dwi(
+        volume=InMemoryVolumeResource(
+            array=rng.random(size=(3, 4, 5, n_vols), dtype=np.float32),
+            affine=random_affine,
+            metadata=dict(small_nifti_header),
+        ),
+        bval=InMemoryBvalResource(array=rng.integers(0, 3000, n_vols).astype(float)),
+        bvec=InMemoryBvecResource(array=bvec_array),
+    )
 
-    def test_true(self, tmp_path: Path) -> None:
-        pc = PipelineCache(tmp_path, force=True)
-        assert pc.is_forced("any_step")
 
-    def test_set_match(self, tmp_path: Path) -> None:
-        pc = PipelineCache(tmp_path, force={"step_a"})
-        assert pc.is_forced("step_a")
+# ---------------------------------------------------------------------------
+# PipelineCache.is_forced
+# ---------------------------------------------------------------------------
 
-    def test_set_no_match(self, tmp_path: Path) -> None:
-        pc = PipelineCache(tmp_path, force={"step_b"})
-        assert not pc.is_forced("step_a")
+
+def test_is_forced_false(tmp_path: Path) -> None:
+    pc = PipelineCache(tmp_path, force=False)
+    assert not pc.is_forced("any_step")
+
+
+def test_is_forced_true(tmp_path: Path) -> None:
+    pc = PipelineCache(tmp_path, force=True)
+    assert pc.is_forced("any_step")
+
+
+def test_is_forced_set_match(tmp_path: Path) -> None:
+    pc = PipelineCache(tmp_path, force={"step_a"})
+    assert pc.is_forced("step_a")
+
+
+def test_is_forced_set_no_match(tmp_path: Path) -> None:
+    pc = PipelineCache(tmp_path, force={"step_b"})
+    assert not pc.is_forced("step_a")
 
 
 # ---------------------------------------------------------------------------
@@ -64,41 +107,41 @@ class TestIsForced:
 # ---------------------------------------------------------------------------
 
 
-class TestIsCached:
-    def test_missing_file(self, tmp_path: Path) -> None:
-        pc = PipelineCache(tmp_path)
-        assert not pc.is_cached("step", ["missing.txt"])
+def test_is_cached_missing_file(tmp_path: Path) -> None:
+    pc = PipelineCache(tmp_path)
+    assert not pc.is_cached("step", ["missing.txt"])
 
-    def test_all_files_present(self, tmp_path: Path) -> None:
-        (tmp_path / "out.txt").write_text("x")
-        pc = PipelineCache(tmp_path, force=False)
-        assert pc.is_cached("step", ["out.txt"])
 
-    def test_forced_overrides_present(self, tmp_path: Path) -> None:
-        (tmp_path / "out.txt").write_text("x")
-        pc = PipelineCache(tmp_path, force=True)
-        assert not pc.is_cached("step", ["out.txt"])
+def test_is_cached_all_files_present(tmp_path: Path) -> None:
+    (tmp_path / "out.txt").write_text("x")
+    pc = PipelineCache(tmp_path, force=False)
+    assert pc.is_cached("step", ["out.txt"])
 
-    def test_params_match(self, tmp_path: Path) -> None:
-        (tmp_path / "out.txt").write_text("x")
-        import json
 
-        (tmp_path / "step.params.json").write_text(json.dumps({"x": 1}, sort_keys=True))
-        pc = PipelineCache(tmp_path)
-        assert pc.is_cached("step", ["out.txt"], params={"x": 1})
+def test_is_cached_forced_overrides_present(tmp_path: Path) -> None:
+    (tmp_path / "out.txt").write_text("x")
+    pc = PipelineCache(tmp_path, force=True)
+    assert not pc.is_cached("step", ["out.txt"])
 
-    def test_params_mismatch(self, tmp_path: Path) -> None:
-        (tmp_path / "out.txt").write_text("x")
-        import json
 
-        (tmp_path / "step.params.json").write_text(json.dumps({"x": 1}, sort_keys=True))
-        pc = PipelineCache(tmp_path)
-        assert not pc.is_cached("step", ["out.txt"], params={"x": 99})
+def test_is_cached_params_match(tmp_path: Path) -> None:
+    (tmp_path / "out.txt").write_text("x")
+    (tmp_path / "step.params.json").write_text(json.dumps({"x": 1}, sort_keys=True))
+    pc = PipelineCache(tmp_path)
+    assert pc.is_cached("step", ["out.txt"], params={"x": 1})
 
-    def test_params_file_missing_is_miss(self, tmp_path: Path) -> None:
-        (tmp_path / "out.txt").write_text("x")
-        pc = PipelineCache(tmp_path)
-        assert not pc.is_cached("step", ["out.txt"], params={"x": 1})
+
+def test_is_cached_params_mismatch(tmp_path: Path) -> None:
+    (tmp_path / "out.txt").write_text("x")
+    (tmp_path / "step.params.json").write_text(json.dumps({"x": 1}, sort_keys=True))
+    pc = PipelineCache(tmp_path)
+    assert not pc.is_cached("step", ["out.txt"], params={"x": 99})
+
+
+def test_is_cached_params_file_missing_is_miss(tmp_path: Path) -> None:
+    (tmp_path / "out.txt").write_text("x")
+    pc = PipelineCache(tmp_path)
+    assert not pc.is_cached("step", ["out.txt"], params={"x": 1})
 
 
 # ---------------------------------------------------------------------------
@@ -106,240 +149,288 @@ class TestIsCached:
 # ---------------------------------------------------------------------------
 
 
-class TestContextManager:
-    def test_sets_active_cache(self, tmp_path: Path) -> None:
-        assert _active_cache.get() is None
-        pc = PipelineCache(tmp_path)
+def test_context_manager_sets_active_cache(tmp_path: Path) -> None:
+    assert _active_cache.get() is None
+    pc = PipelineCache(tmp_path)
+    with pc:
+        assert _active_cache.get() is pc
+    assert _active_cache.get() is None
+
+
+def test_context_manager_restores_on_exception(tmp_path: Path) -> None:
+    pc = PipelineCache(tmp_path)
+    try:
         with pc:
-            assert _active_cache.get() is pc
-        assert _active_cache.get() is None
+            error = "Error"
+            raise RuntimeError(error)
+    except RuntimeError:
+        pass
+    assert _active_cache.get() is None
 
-    def test_restores_on_exception(self, tmp_path: Path) -> None:
-        pc = PipelineCache(tmp_path)
-        try:
-            with pc:
-                raise RuntimeError("boom")
-        except RuntimeError:
-            pass
-        assert _active_cache.get() is None
 
-    def test_creates_cache_dir(self, tmp_path: Path) -> None:
-        cache_dir = tmp_path / "nested" / "cache"
-        assert not cache_dir.exists()
-        with PipelineCache(cache_dir):
-            assert cache_dir.is_dir()
+def test_context_manager_creates_cache_dir(tmp_path: Path) -> None:
+    cache_dir = tmp_path / "nested" / "cache"
+    assert not cache_dir.exists()
+    with PipelineCache(cache_dir):
+        assert cache_dir.is_dir()
 
 
 # ---------------------------------------------------------------------------
-# @cacheable (bare, auto-spec)
+# @cacheable mechanism
 # ---------------------------------------------------------------------------
 
 
-class TestCacheable:
-    def test_cache_miss_calls_function(self, tmp_path: Path) -> None:
-        calls: list[int] = []
+def test_cacheable_raises_on_no_return_annotation(tmp_path: Path) -> None:
+    """TypeError is raised on first call within a cache context if no return annotation is present."""
 
-        @cacheable
-        def fn(x: int) -> FakeResource:
-            calls.append(x)
-            return FakeResource(x * 3)
+    @cacheable  # type: ignore[misc]
+    def bad_fn(x: int):
+        pass
 
-        with PipelineCache(tmp_path):
-            result = fn(4)
-
-        assert calls == [4]
-        assert result.value == 12
-
-    def test_cache_hit_skips_function(self, tmp_path: Path) -> None:
-        calls: list[int] = []
-
-        @cacheable
-        def fn(x: int) -> FakeResource:
-            calls.append(x)
-            return FakeResource(x * 3)
-
-        pc = PipelineCache(tmp_path)
-        with pc:
-            fn(4)  # populate cache
-        calls.clear()
-        with pc:
-            result = fn(99)  # different arg — cache hit returns saved value
-
-        assert calls == []  # function not called
-        assert result.value == 12  # loaded from cache (original value)
-
-    def test_outside_context_no_caching(self) -> None:
-        calls: list[int] = []
-
-        @cacheable
-        def fn(x: int) -> FakeResource:
-            calls.append(x)
-            return FakeResource(x)
-
-        result = fn(7)
-        assert calls == [7]
-        assert result.value == 7  # returned directly, not from disk
-
-    def test_parameter_change_triggers_recompute(self, tmp_path: Path) -> None:
-        calls: list[int] = []
-
-        @cacheable
-        def fn(x: int, multiplier: int = 2) -> FakeResource:
-            calls.append(multiplier)
-            return FakeResource(x * multiplier)
-
-        pc = PipelineCache(tmp_path)
-        with pc:
-            fn(5, multiplier=2)
-        calls.clear()
-        with pc:
-            result = fn(5, multiplier=10)  # changed scalar param → recompute
-
-        assert calls == [10]
-        assert result.value == 50
-
-    def test_same_params_no_recompute(self, tmp_path: Path) -> None:
-        calls: list[int] = []
-
-        @cacheable
-        def fn(x: int, multiplier: int = 2) -> FakeResource:
-            calls.append(multiplier)
-            return FakeResource(x * multiplier)
-
-        pc = PipelineCache(tmp_path)
-        with pc:
-            fn(5, multiplier=2)
-        calls.clear()
-        with pc:
-            fn(5, multiplier=2)  # same params → cache hit
-
-        assert calls == []
-
-    def test_type_error_on_no_return_annotation(self) -> None:
-        with pytest.raises(TypeError, match="no resolvable return type"):
-
-            @cacheable
-            def bad_fn(x: int):
-                return FakeResource(x)
-
-    def test_type_error_on_missing_protocol(self) -> None:
-        with pytest.raises(TypeError, match="does not implement the cache protocol"):
-
-            @cacheable
-            def bad_fn(x: int) -> NoCacheProtocol:
-                return NoCacheProtocol()
-
-    def test_functools_wraps_preserved(self) -> None:
-        assert compute_fake.__name__ == "compute_fake"
-
-    def test_force_step_bypasses_cache(self, tmp_path: Path) -> None:
-        calls: list[int] = []
-
-        @cacheable
-        def fn(x: int) -> FakeResource:
-            calls.append(x)
-            return FakeResource(x)
-
-        pc = PipelineCache(tmp_path)
-        with pc:
-            fn(1)
-        calls.clear()
-        with PipelineCache(tmp_path, force={"fn"}):
-            fn(1)
-
-        assert calls == [1]  # forced recompute
+    with (
+        pytest.raises(TypeError, match="no resolvable return type"),
+        PipelineCache(tmp_path),
+    ):
+        bad_fn(1)
 
 
-# ---------------------------------------------------------------------------
-# @cacheable(CacheSpec(...)) — explicit spec
-# ---------------------------------------------------------------------------
-class TestCacheSpec:
-    def test_explicit_spec_miss_and_hit(self, tmp_path: Path) -> None:
-        calls: list[str] = []
+def test_cacheable_raises_on_missing_protocol(tmp_path: Path) -> None:
+    """TypeError is raised on first call within a cache context if return type lacks cache protocol.
 
-        @cacheable(
-            CacheSpec(
-                files=["result.txt"],
-                save=lambda val, d: (d / "result.txt").write_text(val),
-                load=lambda d: (d / "result.txt").read_text(),
-            )
-        )
-        def fn(label: str) -> str:
-            calls.append(label)
-            return label.upper()
+    Uses int as the return type: it is resolvable from the module namespace but does not
+    implement _cache_files / _cache_save / _cache_load.
+    """
 
-        pc = PipelineCache(tmp_path)
-        with pc:
-            r1 = fn("hello")
-        assert r1 == "HELLO"
-        assert calls == ["hello"]
+    @cacheable  # type: ignore[misc]
+    def bad_fn(x: int) -> int:
+        return x
 
-        calls.clear()
-        with pc:
-            r2 = fn("world")  # cache hit — returns previously saved value
-        assert r2 == "HELLO"
-        assert calls == []
+    with (
+        pytest.raises(TypeError, match="does not implement the cache protocol"),
+        PipelineCache(tmp_path),
+    ):
+        bad_fn(1)
 
-    def test_explicit_spec_param_change(self, tmp_path: Path) -> None:
-        calls: list[str] = []
 
-        @cacheable(
-            CacheSpec(
-                files=["result.txt"],
-                save=lambda val, d: (d / "result.txt").write_text(val),
-                load=lambda d: (d / "result.txt").read_text(),
-            )
-        )
-        def fn(label: str) -> str:
-            calls.append(label)
-            return label.upper()
+def test_cacheable_preserves_function_name() -> None:
+    """@cacheable preserves __name__ on the wrapped function."""
+    assert Dti.estimate_from_dwi.__name__ == "estimate_from_dwi"
+    assert Noddi.estimate_from_dwi.__name__ == "estimate_from_dwi"
+    assert Dwi.denoise.__name__ == "denoise"
 
-        pc = PipelineCache(tmp_path)
-        with pc:
-            fn("hello")
-        calls.clear()
-        with pc:
-            r = fn("goodbye")  # scalar param changed → recompute
 
-        assert calls == ["goodbye"]
-        assert r == "GOODBYE"
+def test_cacheable_no_op_outside_context(dwi3: Dwi) -> None:
+    """@cacheable is a transparent pass-through when no PipelineCache context is active."""
+    dti = dwi3.estimate_dti()
+    assert isinstance(dti, Dti)
 
 
 # ---------------------------------------------------------------------------
 # PipelineCache.status
 # ---------------------------------------------------------------------------
-class TestStatus:
-    def test_missing_shows_false(self, tmp_path: Path) -> None:
-        pc = PipelineCache(tmp_path)
-        result = pc.status([compute_fake])
-        assert result["compute_fake"] is False
 
-    def test_present_shows_true(self, tmp_path: Path) -> None:
-        pc = PipelineCache(tmp_path)
-        with pc:
-            compute_fake(3)
-        result = pc.status([compute_fake])
-        assert result["compute_fake"] is True
 
-    def test_non_cacheable_skipped(self, tmp_path: Path) -> None:
-        def plain() -> None:
-            pass
+def test_status_missing_shows_false(tmp_path: Path) -> None:
+    pc = PipelineCache(tmp_path)
+    result = pc.status([Dti.estimate_from_dwi])
+    assert result["Dti.estimate_from_dwi"] is False
 
-        pc = PipelineCache(tmp_path)
-        assert pc.status([plain]) == {}
 
-    def test_multiple_steps(self, tmp_path: Path) -> None:
-        @cacheable
-        def step_a(x: int) -> FakeResource:
-            return FakeResource(x)
+def test_status_present_shows_true(dwi3: Dwi, tmp_path: Path) -> None:
+    pc = PipelineCache(tmp_path)
+    with pc:
+        dwi3.estimate_dti()
+    result = pc.status([Dti.estimate_from_dwi])
+    assert result["Dti.estimate_from_dwi"] is True
 
-        @cacheable
-        def step_b(x: int) -> FakeResource:
-            return FakeResource(x)
 
-        pc = PipelineCache(tmp_path)
-        with pc:
-            step_a(1)
-        result = pc.status([step_a, step_b])
-        assert result["step_a"] is True
-        assert result["step_b"] is False
+def test_status_non_cacheable_skipped(tmp_path: Path) -> None:
+    def plain() -> None:
+        pass
+
+    pc = PipelineCache(tmp_path)
+    assert pc.status([plain]) == {}
+
+
+def test_status_multiple_steps(dwi3: Dwi, tmp_path: Path) -> None:
+    """status reflects which steps have been cached and which have not."""
+    pc = PipelineCache(tmp_path)
+    with pc:
+        dwi3.estimate_dti()
+    result = pc.status([Dti.estimate_from_dwi, Noddi.estimate_from_dwi])
+    assert result["Dti.estimate_from_dwi"] is True
+    assert result["Noddi.estimate_from_dwi"] is False
+
+
+# ---------------------------------------------------------------------------
+# Integration tests
+# ---------------------------------------------------------------------------
+
+
+def test_estimate_dti_with_caching(dwi3: Dwi, tmp_path: Path) -> None:
+    """DTI results are saved to cache and reloaded correctly on the second call."""
+    pc = PipelineCache(tmp_path)
+    with pc:
+        dti = dwi3.estimate_dti()
+
+    assert np.allclose(dti.volume.get_affine(), dwi3.volume.get_affine())
+    assert dti.volume.get_array().shape[:3] == (3, 4, 5)
+    assert (tmp_path / "dti.nii.gz").exists()
+    assert pc.status([Dti.estimate_from_dwi])["Dti.estimate_from_dwi"] is True
+
+    # Second call returns the same result loaded from cache
+    with pc:
+        dti_cached = dwi3.estimate_dti()
+    assert np.allclose(dti_cached.volume.get_array(), dti.volume.get_array())
+
+
+def test_estimate_dti_force_recompute(dwi3: Dwi, tmp_path: Path, mocker) -> None:
+    """force={"estimate_from_dwi"} causes DTI to recompute even when a cache exists."""
+    pc = PipelineCache(tmp_path)
+    with pc:
+        dwi3.estimate_dti()
+
+    save_spy = mocker.spy(Dti, "_cache_save")
+    with PipelineCache(tmp_path, force={"estimate_from_dwi"}):
+        dwi3.estimate_dti()
+
+    save_spy.assert_called_once()
+
+
+def _make_amico_mock(mocker, rng: np.random.Generator) -> MagicMock:
+    """Patch AMICO internals so Noddi.estimate_from_dwi runs without the full AMICO stack.
+
+    The @cacheable wrapper on estimate_from_dwi is left intact so that caching
+    behaviour can be tested end-to-end.
+    """
+    mock_ae = MagicMock()
+    mock_ae.RESULTS = {
+        "MAPs": rng.random(size=(3, 4, 5, 3)).astype(np.float32),
+        "DIRs": rng.random(size=(3, 4, 5, 3)).astype(np.float32),
+    }
+    mock_ae.model.maps_name = ["NDI", "ODI", "FWF"]
+    mocker.patch("kwneuro.noddi.amico.setup")
+    mocker.patch("kwneuro.noddi.amico.Evaluation", return_value=mock_ae)
+    mocker.patch("kwneuro.noddi.amico.util.fsl2scheme")
+    return mock_ae
+
+
+def test_estimate_noddi_with_caching(dwi3: Dwi, mocker, tmp_path: Path) -> None:
+    """NODDI results are saved to cache and reloaded correctly on the second call."""
+    mock_ae = _make_amico_mock(mocker, np.random.default_rng(18653))
+
+    pc = PipelineCache(tmp_path)
+    with pc:
+        noddi = dwi3.estimate_noddi()
+
+    assert np.allclose(noddi.volume.get_array(), mock_ae.RESULTS["MAPs"])
+    assert np.allclose(noddi.directions.get_array(), mock_ae.RESULTS["DIRs"])
+    assert np.allclose(noddi.volume.get_affine(), dwi3.volume.get_affine())
+    assert (tmp_path / "noddi.nii.gz").exists()
+    assert (tmp_path / "noddi_directions.nii.gz").exists()
+    assert pc.status([Noddi.estimate_from_dwi])["Noddi.estimate_from_dwi"] is True
+
+    # Second call loads from cache — AMICO fit is not re-invoked
+    mock_ae.fit.reset_mock()
+    with pc:
+        dwi3.estimate_noddi()
+    mock_ae.fit.assert_not_called()
+
+
+def test_estimate_noddi_parameter_change_triggers_recompute(
+    dwi3: Dwi, mocker, tmp_path: Path
+) -> None:
+    """Changing a scalar parameter (dpar) invalidates the NODDI cache and triggers recomputation."""
+    mock_ae = _make_amico_mock(mocker, np.random.default_rng(18653))
+
+    pc = PipelineCache(tmp_path)
+    with pc:
+        dwi3.estimate_noddi(dpar=1.7e-3)
+
+    mock_ae.fit.reset_mock()
+    with pc:
+        dwi3.estimate_noddi(dpar=1.3e-3)  # different dpar → cache miss
+
+    mock_ae.fit.assert_called_once()
+
+
+def test_estimate_noddi_same_params_no_recompute(
+    dwi3: Dwi, mocker, tmp_path: Path
+) -> None:
+    """Calling estimate_noddi with unchanged parameters reuses the cached result."""
+    mock_ae = _make_amico_mock(mocker, np.random.default_rng(18653))
+
+    pc = PipelineCache(tmp_path)
+    with pc:
+        dwi3.estimate_noddi(dpar=1.7e-3)
+
+    mock_ae.fit.reset_mock()
+    with pc:
+        dwi3.estimate_noddi(dpar=1.7e-3)  # same params → cache hit
+
+    mock_ae.fit.assert_not_called()
+
+
+def test_compute_csd_peaks_with_caching(dwi3: Dwi, mocker, tmp_path: Path) -> None:
+    """CSD peaks are saved to cache via CacheSpec and reloaded correctly on the second call.
+
+    compute_csd_peaks uses @cacheable(CacheSpec(...)) rather than the bare @cacheable
+    decorator, so this test exercises the explicit-spec caching path with fixed output
+    filenames and custom save/load lambdas.
+    """
+    rng = np.random.default_rng(18653)
+    n_peaks = 5
+
+    # Mock the DIPY CSD model and peak-finding to avoid running the full pipeline,
+    mock_peaks = MagicMock()
+    mock_peaks.peak_dirs = rng.random(size=(3, 4, 5, n_peaks, 3)).astype(np.float32)
+    mock_peaks.peak_values = rng.random(size=(3, 4, 5, n_peaks)).astype(np.float32)
+    mocker.patch("kwneuro.csd.ConstrainedSphericalDeconvModel")
+    mock_peaks_from_model = mocker.patch(
+        "kwneuro.csd.peaks_from_model", return_value=mock_peaks
+    )
+
+    mask = InMemoryVolumeResource(
+        array=np.ones((3, 4, 5), dtype=np.float32),
+        affine=dwi3.volume.get_affine(),
+    )
+    mock_response = MagicMock()
+
+    pc = PipelineCache(tmp_path)
+    with pc:
+        peak_dirs, peak_values = compute_csd_peaks(dwi3, mask, response=mock_response)
+
+    # Result contains the expected arrays
+    assert np.allclose(peak_dirs.get_array(), mock_peaks.peak_dirs)
+    assert np.allclose(peak_values.get_array(), mock_peaks.peak_values)
+
+    # Cache files (fixed names from CacheSpec) exist and status reports cached
+    assert (tmp_path / "csd_peak_dirs.nii.gz").exists()
+    assert (tmp_path / "csd_peak_values.nii.gz").exists()
+    assert pc.status([compute_csd_peaks])["compute_csd_peaks"] is True
+
+    # Second call loads from cache — peaks_from_model is not re-invoked
+    mock_peaks_from_model.reset_mock()
+    with pc:
+        compute_csd_peaks(dwi3, mask, response=mock_response)
+    mock_peaks_from_model.assert_not_called()
+
+
+def test_denoise_with_caching(dwi4: Dwi, tmp_path: Path) -> None:
+    """Denoised DWI is saved to cache and reloaded correctly on the second call."""
+    pc = PipelineCache(tmp_path)
+    with pc:
+        denoised = dwi4.denoise()
+
+    assert isinstance(denoised, Dwi)
+    assert denoised.volume.get_array().shape == dwi4.volume.get_array().shape
+    assert np.allclose(denoised.volume.get_affine(), dwi4.volume.get_affine())
+    assert (tmp_path / "denoise.nii.gz").exists()
+    assert (tmp_path / "denoise.bval").exists()
+    assert (tmp_path / "denoise.bvec").exists()
+    assert pc.status([Dwi.denoise])["Dwi.denoise"] is True
+
+    # Second call returns the same volume loaded from cache
+    with pc:
+        denoised_cached = dwi4.denoise()
+    assert np.allclose(denoised_cached.volume.get_array(), denoised.volume.get_array())

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -11,6 +11,7 @@ from scipy.linalg import expm
 
 from kwneuro.cache import (
     Cache,
+    CacheSpec,
     _active_cache,
     cacheable,
 )
@@ -21,6 +22,7 @@ from kwneuro.noddi import Noddi
 from kwneuro.resource import (
     InMemoryBvalResource,
     InMemoryBvecResource,
+    InMemoryResponseFunctionResource,
     InMemoryVolumeResource,
 )
 
@@ -124,24 +126,46 @@ def test_is_cached_forced_overrides_present(tmp_path: Path) -> None:
     assert not pc.is_cached("step", ["out.txt"])
 
 
-def test_is_cached_params_match(tmp_path: Path) -> None:
+def test_is_cached_scalars_match(tmp_path: Path) -> None:
     (tmp_path / "out.txt").write_text("x")
-    (tmp_path / "step.params.json").write_text(json.dumps({"x": 1}, sort_keys=True))
+    (tmp_path / "step.params.json").write_text(
+        json.dumps({"scalars": {"x": 1}}, sort_keys=True)
+    )
     pc = Cache(tmp_path)
-    assert pc.is_cached("step", ["out.txt"], params={"x": 1})
+    assert pc.is_cached("step", ["out.txt"], scalars={"x": 1})
 
 
-def test_is_cached_params_mismatch(tmp_path: Path) -> None:
+def test_is_cached_scalars_mismatch(tmp_path: Path) -> None:
     (tmp_path / "out.txt").write_text("x")
-    (tmp_path / "step.params.json").write_text(json.dumps({"x": 1}, sort_keys=True))
+    (tmp_path / "step.params.json").write_text(
+        json.dumps({"scalars": {"x": 1}}, sort_keys=True)
+    )
     pc = Cache(tmp_path)
-    assert not pc.is_cached("step", ["out.txt"], params={"x": 99})
+    assert not pc.is_cached("step", ["out.txt"], scalars={"x": 99})
 
 
 def test_is_cached_params_file_missing_is_miss(tmp_path: Path) -> None:
     (tmp_path / "out.txt").write_text("x")
     pc = Cache(tmp_path)
-    assert not pc.is_cached("step", ["out.txt"], params={"x": 1})
+    assert not pc.is_cached("step", ["out.txt"], scalars={"x": 1})
+
+
+def test_is_cached_hashes_match(tmp_path: Path) -> None:
+    (tmp_path / "out.txt").write_text("x")
+    (tmp_path / "step.params.json").write_text(
+        json.dumps({"hashes": {"arr": "abc123"}}, sort_keys=True)
+    )
+    pc = Cache(tmp_path)
+    assert pc.is_cached("step", ["out.txt"], hashes={"arr": "abc123"})
+
+
+def test_is_cached_hashes_mismatch(tmp_path: Path) -> None:
+    (tmp_path / "out.txt").write_text("x")
+    (tmp_path / "step.params.json").write_text(
+        json.dumps({"hashes": {"arr": "abc123"}}, sort_keys=True)
+    )
+    pc = Cache(tmp_path)
+    assert not pc.is_cached("step", ["out.txt"], hashes={"arr": "different"})
 
 
 # ---------------------------------------------------------------------------
@@ -302,6 +326,9 @@ def _make_amico_mock(mocker, rng: np.random.Generator) -> MagicMock:
 
     The @cacheable wrapper on estimate_noddi is left intact so that caching
     behaviour can be tested end-to-end.
+
+    AMICO is an optional pip extra. A fake `amico` module is injected into
+    `sys.modules` so these tests run even when AMICO is not installed.
     """
     mock_ae = MagicMock()
     mock_ae.RESULTS = {
@@ -309,9 +336,17 @@ def _make_amico_mock(mocker, rng: np.random.Generator) -> MagicMock:
         "DIRs": rng.random(size=(3, 4, 5, 3)).astype(np.float32),
     }
     mock_ae.model.maps_name = ["NDI", "ODI", "FWF"]
-    mocker.patch("kwneuro.noddi.amico.setup")
-    mocker.patch("kwneuro.noddi.amico.Evaluation", return_value=mock_ae)
-    mocker.patch("kwneuro.noddi.amico.util.fsl2scheme")
+    # amico is imported inside Noddi.estimate_noddi as ``import amico``. Since
+    # amico is an optional pip extra that may not be installed, we inject fake
+    # module objects into sys.modules first so that ``import amico`` succeeds,
+    # then patch the individual attributes the function actually calls.
+    mock_amico_module = MagicMock()
+    mock_amico_util = MagicMock()
+    mocker.patch.dict(
+        "sys.modules", {"amico": mock_amico_module, "amico.util": mock_amico_util}
+    )
+    mock_amico_module.Evaluation.return_value = mock_ae
+    mock_amico_module.util = mock_amico_util
     return mock_ae
 
 
@@ -394,7 +429,13 @@ def test_compute_csd_peaks_with_caching(dwi3: Dwi, mocker, tmp_path: Path) -> No
         array=np.ones((3, 4, 5), dtype=np.float32),
         affine=dwi3.volume.get_affine(),
     )
-    mock_response = MagicMock()
+    # Use a real InMemoryResponseFunctionResource so it is content-fingerprinted
+    # rather than triggering an untracked-parameter warning (warnings are errors
+    # in this test suite).
+    mock_response = InMemoryResponseFunctionResource(
+        sh_coeffs=np.zeros(5, dtype=np.float64),
+        avg_signal=np.float32(1.0),
+    )
 
     pc = Cache(tmp_path)
     with pc:
@@ -434,3 +475,64 @@ def test_denoise_with_caching(dwi4: Dwi, tmp_path: Path) -> None:
     with pc:
         denoised_cached = dwi4.denoise()
     assert np.allclose(denoised_cached.volume.get_array(), denoised.volume.get_array())
+
+
+# ---------------------------------------------------------------------------
+# Content fingerprinting
+# ---------------------------------------------------------------------------
+
+
+def test_params_json_has_scalars_and_hashes(dwi3: Dwi, tmp_path: Path) -> None:
+    """The params sidecar contains separate 'scalars' and 'hashes' sections."""
+    with Cache(tmp_path):
+        dwi3.estimate_dti()
+
+    params = json.loads((tmp_path / "estimate_dti.params.json").read_text())
+    # Scalar arguments (mask=None) are human-readable in the "scalars" section.
+    assert "scalars" in params
+    assert params["scalars"]["mask"] is None
+    # Non-scalar arguments (dwi, the Dwi dataclass) are sha256 fingerprints.
+    assert "hashes" in params
+    assert "dwi" in params["hashes"]
+    assert len(params["hashes"]["dwi"]) == 64  # sha256 hex digest is 64 chars
+
+
+def test_data_change_triggers_recompute(dwi3: Dwi, tmp_path: Path, mocker) -> None:
+    """Modifying the imaging array invalidates the cache even when scalar params are unchanged."""
+    pc = Cache(tmp_path)
+    with pc:
+        dwi3.estimate_dti()
+
+    save_spy = mocker.spy(Dti, "_cache_save")
+
+    # Mutate the underlying array — same scalar params, different data fingerprint.
+    assert isinstance(dwi3.volume, InMemoryVolumeResource)
+    dwi3.volume.array[0, 0, 0, 0] += 1.0
+
+    with pc:
+        dwi3.estimate_dti()
+
+    save_spy.assert_called_once()  # recomputed because the data hash changed
+
+
+def test_untracked_param_warns(tmp_path: Path) -> None:
+    """A UserWarning is issued for parameters that cannot be fingerprinted."""
+
+    class Opaque:
+        """Not a scalar, not a dataclass, not a numpy type — cannot be fingerprinted."""
+
+    def _save(result: str, d: Path) -> None:
+        (d / "out.txt").write_text(result)
+
+    @cacheable(  # type: ignore[untyped-decorator]
+        CacheSpec(
+            files=["out.txt"],
+            save=_save,
+            load=lambda d: (d / "out.txt").read_text(),
+        )
+    )
+    def fn(_x: object) -> str:
+        return "result"
+
+    with pytest.warns(UserWarning, match="cannot be fingerprinted"), Cache(tmp_path):
+        fn(Opaque())

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -10,7 +10,7 @@ import pytest
 from scipy.linalg import expm
 
 from kwneuro.cache import (
-    PipelineCache,
+    Cache,
     _active_cache,
     cacheable,
 )
@@ -78,69 +78,69 @@ def dwi4(random_affine, small_nifti_header) -> Dwi:
 
 
 # ---------------------------------------------------------------------------
-# PipelineCache.is_forced
+# Cache.is_forced
 # ---------------------------------------------------------------------------
 
 
 def test_is_forced_false(tmp_path: Path) -> None:
-    pc = PipelineCache(tmp_path, force=False)
+    pc = Cache(tmp_path, force=False)
     assert not pc.is_forced("any_step")
 
 
 def test_is_forced_true(tmp_path: Path) -> None:
-    pc = PipelineCache(tmp_path, force=True)
+    pc = Cache(tmp_path, force=True)
     assert pc.is_forced("any_step")
 
 
 def test_is_forced_set_match(tmp_path: Path) -> None:
-    pc = PipelineCache(tmp_path, force={"step_a"})
+    pc = Cache(tmp_path, force={"step_a"})
     assert pc.is_forced("step_a")
 
 
 def test_is_forced_set_no_match(tmp_path: Path) -> None:
-    pc = PipelineCache(tmp_path, force={"step_b"})
+    pc = Cache(tmp_path, force={"step_b"})
     assert not pc.is_forced("step_a")
 
 
 # ---------------------------------------------------------------------------
-# PipelineCache.is_cached
+# Cache.is_cached
 # ---------------------------------------------------------------------------
 
 
 def test_is_cached_missing_file(tmp_path: Path) -> None:
-    pc = PipelineCache(tmp_path)
+    pc = Cache(tmp_path)
     assert not pc.is_cached("step", ["missing.txt"])
 
 
 def test_is_cached_all_files_present(tmp_path: Path) -> None:
     (tmp_path / "out.txt").write_text("x")
-    pc = PipelineCache(tmp_path, force=False)
+    pc = Cache(tmp_path, force=False)
     assert pc.is_cached("step", ["out.txt"])
 
 
 def test_is_cached_forced_overrides_present(tmp_path: Path) -> None:
     (tmp_path / "out.txt").write_text("x")
-    pc = PipelineCache(tmp_path, force=True)
+    pc = Cache(tmp_path, force=True)
     assert not pc.is_cached("step", ["out.txt"])
 
 
 def test_is_cached_params_match(tmp_path: Path) -> None:
     (tmp_path / "out.txt").write_text("x")
     (tmp_path / "step.params.json").write_text(json.dumps({"x": 1}, sort_keys=True))
-    pc = PipelineCache(tmp_path)
+    pc = Cache(tmp_path)
     assert pc.is_cached("step", ["out.txt"], params={"x": 1})
 
 
 def test_is_cached_params_mismatch(tmp_path: Path) -> None:
     (tmp_path / "out.txt").write_text("x")
     (tmp_path / "step.params.json").write_text(json.dumps({"x": 1}, sort_keys=True))
-    pc = PipelineCache(tmp_path)
+    pc = Cache(tmp_path)
     assert not pc.is_cached("step", ["out.txt"], params={"x": 99})
 
 
 def test_is_cached_params_file_missing_is_miss(tmp_path: Path) -> None:
     (tmp_path / "out.txt").write_text("x")
-    pc = PipelineCache(tmp_path)
+    pc = Cache(tmp_path)
     assert not pc.is_cached("step", ["out.txt"], params={"x": 1})
 
 
@@ -151,14 +151,14 @@ def test_is_cached_params_file_missing_is_miss(tmp_path: Path) -> None:
 
 def test_context_manager_sets_active_cache(tmp_path: Path) -> None:
     assert _active_cache.get() is None
-    pc = PipelineCache(tmp_path)
+    pc = Cache(tmp_path)
     with pc:
         assert _active_cache.get() is pc
     assert _active_cache.get() is None
 
 
 def test_context_manager_restores_on_exception(tmp_path: Path) -> None:
-    pc = PipelineCache(tmp_path)
+    pc = Cache(tmp_path)
     try:
         with pc:
             error = "Error"
@@ -171,7 +171,7 @@ def test_context_manager_restores_on_exception(tmp_path: Path) -> None:
 def test_context_manager_creates_cache_dir(tmp_path: Path) -> None:
     cache_dir = tmp_path / "nested" / "cache"
     assert not cache_dir.exists()
-    with PipelineCache(cache_dir):
+    with Cache(cache_dir):
         assert cache_dir.is_dir()
 
 
@@ -183,13 +183,13 @@ def test_context_manager_creates_cache_dir(tmp_path: Path) -> None:
 def test_cacheable_raises_on_no_return_annotation(tmp_path: Path) -> None:
     """TypeError is raised on first call within a cache context if no return annotation is present."""
 
-    @cacheable  # type: ignore[misc]
+    @cacheable
     def bad_fn(x: int):
         pass
 
     with (
         pytest.raises(TypeError, match="no resolvable return type"),
-        PipelineCache(tmp_path),
+        Cache(tmp_path),
     ):
         bad_fn(1)
 
@@ -201,13 +201,13 @@ def test_cacheable_raises_on_missing_protocol(tmp_path: Path) -> None:
     implement _cache_files / _cache_save / _cache_load.
     """
 
-    @cacheable  # type: ignore[misc]
+    @cacheable
     def bad_fn(x: int) -> int:
         return x
 
     with (
         pytest.raises(TypeError, match="does not implement the cache protocol"),
-        PipelineCache(tmp_path),
+        Cache(tmp_path),
     ):
         bad_fn(1)
 
@@ -220,24 +220,24 @@ def test_cacheable_preserves_function_name() -> None:
 
 
 def test_cacheable_no_op_outside_context(dwi3: Dwi) -> None:
-    """@cacheable is a transparent pass-through when no PipelineCache context is active."""
+    """@cacheable is a transparent pass-through when no Cache context is active."""
     dti = dwi3.estimate_dti()
     assert isinstance(dti, Dti)
 
 
 # ---------------------------------------------------------------------------
-# PipelineCache.status
+# Cache.status
 # ---------------------------------------------------------------------------
 
 
 def test_status_missing_shows_false(tmp_path: Path) -> None:
-    pc = PipelineCache(tmp_path)
+    pc = Cache(tmp_path)
     result = pc.status([Dti.estimate_dti])
     assert result["Dti.estimate_dti"] is False
 
 
 def test_status_present_shows_true(dwi3: Dwi, tmp_path: Path) -> None:
-    pc = PipelineCache(tmp_path)
+    pc = Cache(tmp_path)
     with pc:
         dwi3.estimate_dti()
     result = pc.status([Dti.estimate_dti])
@@ -248,13 +248,13 @@ def test_status_non_cacheable_skipped(tmp_path: Path) -> None:
     def plain() -> None:
         pass
 
-    pc = PipelineCache(tmp_path)
+    pc = Cache(tmp_path)
     assert pc.status([plain]) == {}
 
 
 def test_status_multiple_steps(dwi3: Dwi, tmp_path: Path) -> None:
     """status reflects which steps have been cached and which have not."""
-    pc = PipelineCache(tmp_path)
+    pc = Cache(tmp_path)
     with pc:
         dwi3.estimate_dti()
     result = pc.status([Dti.estimate_dti, Noddi.estimate_noddi])
@@ -269,7 +269,7 @@ def test_status_multiple_steps(dwi3: Dwi, tmp_path: Path) -> None:
 
 def test_estimate_dti_with_caching(dwi3: Dwi, tmp_path: Path) -> None:
     """DTI results are saved to cache and reloaded correctly on the second call."""
-    pc = PipelineCache(tmp_path)
+    pc = Cache(tmp_path)
     with pc:
         dti = dwi3.estimate_dti()
 
@@ -286,12 +286,12 @@ def test_estimate_dti_with_caching(dwi3: Dwi, tmp_path: Path) -> None:
 
 def test_estimate_dti_force_recompute(dwi3: Dwi, tmp_path: Path, mocker) -> None:
     """force={"estimate_dti"} causes DTI to recompute even when a cache exists."""
-    pc = PipelineCache(tmp_path)
+    pc = Cache(tmp_path)
     with pc:
         dwi3.estimate_dti()
 
     save_spy = mocker.spy(Dti, "_cache_save")
-    with PipelineCache(tmp_path, force={"estimate_dti"}):
+    with Cache(tmp_path, force={"estimate_dti"}):
         dwi3.estimate_dti()
 
     save_spy.assert_called_once()
@@ -319,7 +319,7 @@ def test_estimate_noddi_with_caching(dwi3: Dwi, mocker, tmp_path: Path) -> None:
     """NODDI results are saved to cache and reloaded correctly on the second call."""
     mock_ae = _make_amico_mock(mocker, np.random.default_rng(18653))
 
-    pc = PipelineCache(tmp_path)
+    pc = Cache(tmp_path)
     with pc:
         noddi = dwi3.estimate_noddi()
 
@@ -343,7 +343,7 @@ def test_estimate_noddi_parameter_change_triggers_recompute(
     """Changing a scalar parameter (dpar) invalidates the NODDI cache and triggers recomputation."""
     mock_ae = _make_amico_mock(mocker, np.random.default_rng(18653))
 
-    pc = PipelineCache(tmp_path)
+    pc = Cache(tmp_path)
     with pc:
         dwi3.estimate_noddi(dpar=1.7e-3)
 
@@ -360,7 +360,7 @@ def test_estimate_noddi_same_params_no_recompute(
     """Calling estimate_noddi with unchanged parameters reuses the cached result."""
     mock_ae = _make_amico_mock(mocker, np.random.default_rng(18653))
 
-    pc = PipelineCache(tmp_path)
+    pc = Cache(tmp_path)
     with pc:
         dwi3.estimate_noddi(dpar=1.7e-3)
 
@@ -396,7 +396,7 @@ def test_compute_csd_peaks_with_caching(dwi3: Dwi, mocker, tmp_path: Path) -> No
     )
     mock_response = MagicMock()
 
-    pc = PipelineCache(tmp_path)
+    pc = Cache(tmp_path)
     with pc:
         peak_dirs, peak_values = compute_csd_peaks(dwi3, mask, response=mock_response)
 
@@ -418,7 +418,7 @@ def test_compute_csd_peaks_with_caching(dwi3: Dwi, mocker, tmp_path: Path) -> No
 
 def test_denoise_with_caching(dwi4: Dwi, tmp_path: Path) -> None:
     """Denoised DWI is saved to cache and reloaded correctly on the second call."""
-    pc = PipelineCache(tmp_path)
+    pc = Cache(tmp_path)
     with pc:
         denoised = dwi4.denoise()
 

--- a/tests/test_dwi.py
+++ b/tests/test_dwi.py
@@ -410,7 +410,7 @@ def test_estimate_noddi(dwi3: Dwi, mocker, tmp_path: Path, random_affine: np.nda
 
     mock_estimate_noddi = mocker.patch.object(
         Noddi,
-        "estimate_from_dwi",
+        "estimate_noddi",
         return_value=mock_noddi,
     )
 


### PR DESCRIPTION
**Summary**

 Adds `kwneuro.cache`, a lightweight on-disk caching system for the kwneuro pipeline. Wrapping any set of pipeline calls in a `with PipelineCache(cache_dir):` block causes each `@cacheable`-decorated function to save its output on first run and reload it automatically on subsequent runs, skipping the underlying computation entirely.

  **How it works**
An active Cache is stored in a `ContextVar`. Any `@cacheable`-decorated function checks the context on each call: outside a `with Cache(...):` block it runs normally; inside one it checks for cached output files and either loads them or runs the computation and saves the result.

Two strategies are supported for making a function cacheable:
  - Cache protocol — the return type implements `_cache_files`,` _cache_save`, and `_cache_load`. This is used for Dti, Noddi, Dwi, and VolumeResource subclasses, where the type owns its own serialisation logic. Decorate with  
  bare `@cacheable`.
- CacheSpec — an explicit spec providing files, save, and load callables, used when the return type cannot carry the protocol (e.g. the `tuple[VolumeResource, VolumeResource]` returned by `compute_csd_peaks`). Decorate with `@cacheable(CacheSpec(...))`.

Each argument is classified at call time: scalars `(int, float, str, bool, None)` are stored as human-readable JSON, while non-scalar inputs (dataclasses, numpy arrays, Path objects, dicts, and lists) are hashed with sha256. Both sections are written to a `.params.json` sidecar file alongside the cached outputs, and a mismatch in either triggers a cache miss on the next run. Arguments that cannot be fingerprinted emit a `UserWarning` rather than silently going untracked.