### PR TITLE
Move HD-BET, TractSeg, AMICO, and neuroCombat to optional pip extras

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -17,8 +17,12 @@ uv sync --extra dev
 ```
 
 This creates a virtual environment under `.venv/`, installs kwneuro in editable
-mode with all development dependencies, and respects the committed `uv.lock` for
-reproducible installs.
+mode with all development dependencies (including all optional extras), and
+respects the committed `uv.lock` for reproducible installs.
+
+Note: CI uses `uv sync --extra test`, which installs only the lightweight
+optional deps needed for tests (neuroCombat). The heavier optional deps (HD-BET,
+TractSeg, AMICO) are mocked in tests and not required in CI.
 
 Common tasks:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.12"]
+        python-version: ["3.10", "3.13"]
         runs-on: [ubuntu-latest, windows-latest, macos-latest]
     steps:
       - uses: actions/checkout@v6

--- a/README.md
+++ b/README.md
@@ -37,7 +37,9 @@ Diffusion MRI analysis typically requires stitching together several packages
 file conventions, and coordinate quirks. kwneuro wraps the best of these tools
 behind a single, pip-installable Python interface so you can:
 
-- **Get started fast** -- no system-level dependencies to configure.
+- **Get started fast** -- core analysis (DTI, CSD, registration, template
+  building) works out of the box. Additional tools (brain extraction, NODDI,
+  tract segmentation, harmonization) are available as optional extras.
 - **Swap models easily** -- go from DTI to NODDI to CSD without rewriting your
   script.
 - **Work lazily or eagerly** -- data stays on disk until you call `.load()`, so
@@ -52,7 +54,17 @@ friction.
 ## Installation
 
 ```bash
-pip install kwneuro
+pip install kwneuro             # Core (DTI, CSD, registration, templates)
+pip install kwneuro[all]        # Everything including optional extras
+```
+
+Individual optional extras can also be installed separately:
+
+```bash
+pip install kwneuro[hdbet]      # Brain extraction (HD-BET)
+pip install kwneuro[noddi]      # NODDI estimation (AMICO)
+pip install kwneuro[tractseg]   # Tract segmentation (TractSeg)
+pip install kwneuro[combat]     # ComBat harmonization (neuroCombat)
 ```
 
 Requires Python 3.10+.
@@ -70,15 +82,14 @@ dwi = Dwi(
     FslBvecResource("sub-01_dwi.bvec"),
 ).load()
 
-# Denoise and extract a brain mask
+# Denoise and fit DTI (core -- no extras needed)
 dwi = dwi.denoise()
-mask = dwi.extract_brain()
-
-# Fit DTI and get FA / MD maps
-dti = dwi.estimate_dti(mask=mask)
+dti = dwi.estimate_dti()
 fa, md = dti.get_fa_md()
 
-# Fit NODDI (needs multi-shell data)
+# Brain extraction and NODDI require optional extras:
+#   pip install kwneuro[hdbet,noddi]
+mask = dwi.extract_brain()
 noddi = dwi.estimate_noddi(mask=mask)
 
 # Save everything to disk
@@ -89,17 +100,17 @@ noddi.save("output/noddi.nii.gz")
 
 ## What's included
 
-| Capability             | What it does                                                      | Powered by  |
-| ---------------------- | ----------------------------------------------------------------- | ----------- |
-| **Denoising**          | Patch2Self self-supervised denoising                              | DIPY        |
-| **Brain extraction**   | Deep-learning brain masking from mean b=0                         | HD-BET      |
-| **DTI**                | Tensor fitting, FA, MD, eigenvalue decomposition                  | DIPY        |
-| **NODDI**              | Neurite density, orientation dispersion, free water fraction      | AMICO       |
-| **CSD**                | Fiber orientation distributions and peak extraction               | DIPY        |
-| **Tract segmentation** | 72 white-matter bundles from CSD peaks                            | TractSeg    |
-| **Registration**       | Pairwise registration (rigid, affine, SyN)                        | ANTs        |
-| **Template building**  | Iterative unbiased population templates (single- or multi-metric) | ANTs        |
-| **Harmonization**      | ComBat site-effect removal for multi-site scalar maps             | neuroCombat |
+| Capability             | What it does                                                      | Powered by  | Extra        |
+| ---------------------- | ----------------------------------------------------------------- | ----------- | ------------ |
+| **Denoising**          | Patch2Self self-supervised denoising                              | DIPY        |              |
+| **Brain extraction**   | Deep-learning brain masking from mean b=0                         | HD-BET      | `[hdbet]`    |
+| **DTI**                | Tensor fitting, FA, MD, eigenvalue decomposition                  | DIPY        |              |
+| **NODDI**              | Neurite density, orientation dispersion, free water fraction      | AMICO       | `[noddi]`    |
+| **CSD**                | Fiber orientation distributions and peak extraction               | DIPY        |              |
+| **Tract segmentation** | 72 white-matter bundles from CSD peaks                            | TractSeg    | `[tractseg]` |
+| **Registration**       | Pairwise registration (rigid, affine, SyN)                        | ANTs        |              |
+| **Template building**  | Iterative unbiased population templates (single- or multi-metric) | ANTs        |              |
+| **Harmonization**      | ComBat site-effect removal for multi-site scalar maps             | neuroCombat | `[combat]`   |
 
 <!-- GETTING-STARTED-END -->
 

--- a/notebooks/README.md
+++ b/notebooks/README.md
@@ -6,28 +6,31 @@ CI linting.
 
 ## Running a notebook
 
-Install the notebook dependencies with
-[uv](https://docs.astral.sh/uv/getting-started/installation/), then open a
-notebook:
+From the `notebooks/` directory, first convert the Jupytext `.py` files to
+`.ipynb` (one-time step, no project dependencies needed):
 
-```console
-$ uv sync --extra notebooks
-$ cd notebooks
-$ uv run jupytext --to notebook example-pipeline.py
-$ uv run jupyter notebook example-pipeline.ipynb
+```bash
+cd notebooks
+uv run --with jupytext jupytext --to ipynb *.py
 ```
 
-Or, if you have Jupytext's Jupyter extension enabled, simply open the `.py` file
-directly in Jupyter:
+Then open a specific notebook with exactly the extras it needs:
 
-```console
-$ uv run jupyter notebook example-pipeline.py
+```bash
+uv run --extra notebooks --extra hdbet --extra noddi --extra tractseg \
+    jupyter notebook example-pipeline.ipynb
+
+uv run --extra notebooks --extra combat \
+    jupyter notebook example-harmonization.ipynb
+
+uv run --extra notebooks \
+    jupyter notebook example-group-template.ipynb
 ```
 
 ### Without uv
 
 ```bash
-pip install -e ".[notebooks]"
+pip install -e ".[notebooks,all]"
 cd notebooks
 jupytext --to notebook example-pipeline.py
 jupyter notebook example-pipeline.ipynb

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ classifiers = [
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "Topic :: Scientific/Engineering",
   "Typing :: Typed",
 ]
@@ -34,24 +35,36 @@ dependencies = [
   "numpy <2.4",
   "dipy >=1.9",
   "pandas",
+  "antspyx>=0.6.2",
+]
+
+[project.optional-dependencies]
+hdbet = [
   "hd-bet == 2.0.1",
+]
+tractseg = [
+  "TractSeg",
+]
+noddi = [
   "dmri-amico == 2.1.1",
   # Required because older amico/setuptools dependency chain
   # imports backports.tarfile (can be removed if amico drops it)
   "backports.tarfile",
-  "TractSeg",
-  "antspyx>=0.6.2",
+]
+combat = [
   "neuroCombat ==0.2.12",
 ]
-
-[project.optional-dependencies]
+all = [
+  "kwneuro[hdbet,tractseg,noddi,combat]",
+]
 test = [
   "pytest >=6",
   "pytest-cov >=3",
   "pytest-mock >=3.14",
+  "kwneuro[combat]",
 ]
 dev = [
-  "kwneuro[test]",
+  "kwneuro[test,all]",
   "pre-commit",
   "pylint",
 ]
@@ -125,7 +138,7 @@ disallow_untyped_defs = true
 disallow_incomplete_defs = true
 
 [[tool.mypy.overrides]]
-module = "neuroCombat.*"
+module = ["neuroCombat.*", "HD_BET.*", "tractseg.*", "amico.*"]
 ignore_missing_imports = true
 
 
@@ -160,7 +173,8 @@ ignore = [
   "PLR09",    # Too many <...>
   "PLR2004",  # Magic value used in comparison
   "ISC001",   # Conflicts with formatter
-  "PLC3002", # Direct call of lambda -- this can often aid code clarity in my opinion
+  "PLC3002",  # Direct call of lambda -- this can often aid code clarity in my opinion
+  "PLC0415",  # import-outside-toplevel -- lazy imports are an intentional pattern for optional deps
 ]
 isort.required-imports = ["from __future__ import annotations"]
 # Uncomment if using a _compat.typing backport
@@ -178,6 +192,7 @@ similarities.ignore-imports = "yes"
 messages_control.disable = [
   "design",
   "fixme",
+  "import-outside-toplevel",
   "line-too-long",
   "missing-module-docstring",
   "wrong-import-position",

--- a/src/kwneuro/harmonize.py
+++ b/src/kwneuro/harmonize.py
@@ -9,7 +9,6 @@ from typing import Any
 
 import numpy as np
 import pandas as pd
-from neuroCombat import neuroCombat as _run_combat
 from numpy.typing import NDArray
 
 from kwneuro.resource import InMemoryVolumeResource, VolumeResource
@@ -212,6 +211,15 @@ def harmonize_volumes(
         len(loaded_volumes),
         n_batches,
     )
+
+    try:
+        from neuroCombat import neuroCombat as _run_combat
+    except ImportError:
+        msg = (
+            "neuroCombat is required for harmonization but is not installed. "
+            "Install it with: pip install kwneuro[combat]"
+        )
+        raise ImportError(msg) from None
 
     dat, mask_indices = _flatten_volumes(loaded_volumes, mask_array)
 

--- a/src/kwneuro/masks.py
+++ b/src/kwneuro/masks.py
@@ -5,8 +5,6 @@ import tempfile
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-import torch
-
 from kwneuro.io import NiftiVolumeResource
 from kwneuro.util import PathLike, normalize_path
 
@@ -31,6 +29,15 @@ def _run_hd_bet(
         Default is to use it if the device is GPU and omit it if the device is CPU; this is HD-BET's recommendation.
     """
 
+    try:
+        import torch
+    except ImportError:
+        msg = (
+            "HD-BET requires PyTorch but it is not installed. "
+            "Install it with: pip install kwneuro[hdbet]"
+        )
+        raise ImportError(msg) from None
+
     if device is None:
         device = "cuda" if torch.cuda.is_available() else "cpu"
     if use_tta is None:
@@ -53,13 +60,15 @@ def _run_hd_bet(
         raise FileNotFoundError(msg)
 
     logging.debug("Loading HD_BET")
-    # don't import till now since it takes time to initialize.
-    from HD_BET.checkpoint_download import (  # pylint: disable=import-outside-toplevel  # noqa: PLC0415
-        maybe_download_parameters,
-    )
-    from HD_BET.hd_bet_prediction import (  # pylint: disable=import-outside-toplevel  # noqa: PLC0415
-        get_hdbet_predictor,
-    )
+    try:
+        from HD_BET.checkpoint_download import maybe_download_parameters
+        from HD_BET.hd_bet_prediction import get_hdbet_predictor
+    except ImportError:
+        msg = (
+            "HD-BET is required for brain extraction but is not installed. "
+            "Install it with: pip install kwneuro[hdbet]"
+        )
+        raise ImportError(msg) from None
 
     maybe_download_parameters()
     predictor = get_hdbet_predictor(

--- a/src/kwneuro/noddi.py
+++ b/src/kwneuro/noddi.py
@@ -5,8 +5,6 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-import amico
-
 from kwneuro.io import FslBvalResource, FslBvecResource, NiftiVolumeResource
 from kwneuro.resource import InMemoryVolumeResource, VolumeResource
 from kwneuro.util import (
@@ -78,6 +76,15 @@ class Noddi:
 
         Returns: A Noddi resource containing the estimated parameters.
         """
+        try:
+            import amico
+        except ImportError:
+            msg = (
+                "AMICO is required for NODDI estimation but is not installed. "
+                "Install it with: pip install kwneuro[noddi]"
+            )
+            raise ImportError(msg) from None
+
         amico.setup()
         with tempfile.TemporaryDirectory() as tmpdir:
             ae = amico.Evaluation(output_path=tmpdir)

--- a/src/kwneuro/tractseg.py
+++ b/src/kwneuro/tractseg.py
@@ -3,14 +3,27 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
-from tractseg.python_api import run_tractseg
-
 from kwneuro.csd import combine_csd_peaks_to_vector_volume, compute_csd_peaks
 from kwneuro.resource import ResponseFunctionResource, VolumeResource
 from kwneuro.util import create_estimate_volume_resource
 
 if TYPE_CHECKING:
+    import numpy as np
+
     from kwneuro.dwi import Dwi
+
+
+def _call_tractseg(data: np.ndarray, output_type: str) -> np.ndarray:
+    """Call TractSeg, handling the lazy import."""
+    try:
+        from tractseg.python_api import run_tractseg
+    except ImportError:
+        msg = (
+            "TractSeg is required for tract segmentation but is not installed. "
+            "Install it with: pip install kwneuro[tractseg]"
+        )
+        raise ImportError(msg) from None
+    return run_tractseg(data=data, output_type=output_type)
 
 
 def extract_tractseg(
@@ -50,7 +63,7 @@ def extract_tractseg(
     )
     # Run TractSeg
     logging.info("Running tractseg...")
-    segmentation = run_tractseg(
+    segmentation = _call_tractseg(
         data=csd_peaks_vector.get_array(), output_type=output_type
     )
 

--- a/tests/test_tractseg.py
+++ b/tests/test_tractseg.py
@@ -77,7 +77,7 @@ def test_tractseg(
     # Mock tractseg output
     mock_tractseg_output = np.ones((*vol_shape, 72))
     mocker_run_tract_seg = mocker.patch(
-        "kwneuro.tractseg.run_tractseg", return_value=mock_tractseg_output
+        "kwneuro.tractseg._call_tractseg", return_value=mock_tractseg_output
     )
 
     response = None if response_is_none else response_function

--- a/uv.lock
+++ b/uv.lock
@@ -2686,27 +2686,37 @@ name = "kwneuro"
 source = { editable = "." }
 dependencies = [
     { name = "antspyx" },
-    { name = "backports-tarfile" },
     { name = "click" },
     { name = "dipy", version = "1.11.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "dipy", version = "1.12.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "dmri-amico" },
-    { name = "hd-bet" },
-    { name = "neurocombat" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.3.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "pandas", version = "3.0.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "tractseg" },
 ]
 
 [package.optional-dependencies]
+all = [
+    { name = "backports-tarfile" },
+    { name = "dmri-amico" },
+    { name = "hd-bet" },
+    { name = "neurocombat" },
+    { name = "tractseg" },
+]
+combat = [
+    { name = "neurocombat" },
+]
 dev = [
+    { name = "backports-tarfile" },
+    { name = "dmri-amico" },
+    { name = "hd-bet" },
+    { name = "neurocombat" },
     { name = "pre-commit" },
     { name = "pylint" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "pytest-mock" },
+    { name = "tractseg" },
 ]
 docs = [
     { name = "furo" },
@@ -2720,6 +2730,13 @@ docs = [
     { name = "sphinx-click" },
     { name = "sphinx-copybutton" },
 ]
+hdbet = [
+    { name = "hd-bet" },
+]
+noddi = [
+    { name = "backports-tarfile" },
+    { name = "dmri-amico" },
+]
 notebooks = [
     { name = "ipykernel" },
     { name = "ipywidgets" },
@@ -2728,27 +2745,33 @@ notebooks = [
     { name = "notebook" },
 ]
 test = [
+    { name = "neurocombat" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "pytest-mock" },
+]
+tractseg = [
+    { name = "tractseg" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "antspyx", specifier = ">=0.6.2" },
-    { name = "backports-tarfile" },
+    { name = "backports-tarfile", marker = "extra == 'noddi'" },
     { name = "click", specifier = ">=8.1" },
     { name = "dipy", specifier = ">=1.9" },
-    { name = "dmri-amico", specifier = "==2.1.1" },
+    { name = "dmri-amico", marker = "extra == 'noddi'", specifier = "==2.1.1" },
     { name = "furo", marker = "extra == 'docs'", specifier = ">=2023.8.17" },
-    { name = "hd-bet", specifier = "==2.0.1" },
+    { name = "hd-bet", marker = "extra == 'hdbet'", specifier = "==2.0.1" },
     { name = "ipykernel", marker = "extra == 'notebooks'" },
     { name = "ipywidgets", marker = "extra == 'notebooks'" },
     { name = "jupytext", marker = "extra == 'notebooks'" },
-    { name = "kwneuro", extras = ["test"], marker = "extra == 'dev'" },
+    { name = "kwneuro", extras = ["all", "test"], marker = "extra == 'dev'" },
+    { name = "kwneuro", extras = ["combat"], marker = "extra == 'test'" },
+    { name = "kwneuro", extras = ["combat", "hdbet", "noddi", "tractseg"], marker = "extra == 'all'" },
     { name = "matplotlib", marker = "extra == 'notebooks'" },
     { name = "myst-parser", marker = "extra == 'docs'", specifier = ">=0.13" },
-    { name = "neurocombat", specifier = "==0.2.12" },
+    { name = "neurocombat", marker = "extra == 'combat'", specifier = "==0.2.12" },
     { name = "notebook", marker = "extra == 'notebooks'" },
     { name = "numpy", specifier = "<2.4" },
     { name = "pandas" },
@@ -2762,9 +2785,9 @@ requires-dist = [
     { name = "sphinx-autobuild", marker = "extra == 'docs'", specifier = "==2024.10.3" },
     { name = "sphinx-click", marker = "extra == 'docs'" },
     { name = "sphinx-copybutton", marker = "extra == 'docs'" },
-    { name = "tractseg" },
+    { name = "tractseg", marker = "extra == 'tractseg'" },
 ]
-provides-extras = ["test", "dev", "notebooks", "docs"]
+provides-extras = ["hdbet", "tractseg", "noddi", "combat", "all", "test", "dev", "notebooks", "docs"]
 
 [[package]]
 name = "lark"


### PR DESCRIPTION
I am hoping this change makes maintenance easier in the post-funding era. If one dependency breaks, the whole project doesn't have to break with it.

ants and dipy are more truly  _core_ dependencies that we trust
(and for which the project probably _should_ break if they break) 

Also, installing the "core" is much faster now that it doesn't include pytorch. This has an added advantage of speeding up the CI.

ALSO: updating CI to python 3.13 instead of 3.12 as the "modern" python to test on. For a bit more future-proofing.

<details>

<summary>AI generated PR description</summary>

## Move non-core dependencies to optional pip extras

### What

HD-BET, TractSeg, AMICO, and neuroCombat are now optional pip extras instead of hard dependencies. CI Python matrix bumped from [3.10, 3.12] to [3.10, 3.13].

### Why

If any one of these heavy ML deps breaks (version conflict, build failure, platform incompatibility), the entire `pip install kwneuro` fails — even if you only need DTI or registration. Moving them to extras contains the blast radius and positions the package for lower maintenance burden as dependencies age.

### Key decisions

- **Core vs optional split**: dipy, antspyx, numpy, pandas, click stay core (they power the fundamental abstractions). HD-BET, TractSeg, AMICO, neuroCombat become extras because they're each used by exactly one module and are pinned/fragile.
- **neuroCombat stays in the `test` extra**: its tests run the real library (no mocking), and it's small/pure-Python so there's no cost to including it.
- **Lazy imports with try/except**: each optional dep is imported inside the function that uses it and raises `ImportError` with `pip install kwneuro[extra]` instructions. No shared helper — there are only 4 call sites.
- **TractSeg wrapper function**: TractSeg's import had to move from module-level to function-level, which broke the existing test mock target. Solved with a thin `_call_tractseg()` wrapper that the test mocks instead.
- **Global PLC0415/import-outside-toplevel ignore**: with 4+ modules doing lazy imports as an architectural pattern, per-line `# noqa` was noise.
- **3.13 in CI**: 3.12 was no longer the interesting edge — 3.13 has been stable since Oct 2024.

### Install experience

```
pip install kwneuro             # Core (DTI, CSD, registration, templates)
pip install kwneuro[all]        # Everything
pip install kwneuro[hdbet]      # Just brain extraction
```

`uv sync --extra dev` still gets everything (dev includes all).
</details>