### PR TITLE
Dependabot consolidation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,13 +13,13 @@ updates:
           - "minor"
           - "patch"
 
-  # Maintain dependencies for Python
-  - package-ecosystem: "pip"
+  # Maintain dependencies for Python (managed via uv)
+  - package-ecosystem: "uv"
     directory: "/"
     schedule:
       interval: "monthly"
     groups:
-      python:
+      uv:
         patterns:
           - "*"
         update-types:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,14 +4,24 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     groups:
       actions:
         patterns:
           - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   # Maintain dependencies for Python
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
+    groups:
+      python:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ hdbet = [
   "hd-bet == 2.0.1",
 ]
 tractseg = [
-  "TractSeg",
+  "tractseg",
 ]
 noddi = [
   "dmri-amico == 2.1.1",
@@ -52,7 +52,7 @@ noddi = [
   "backports.tarfile",
 ]
 combat = [
-  "neuroCombat ==0.2.12",
+  "neurocombat ==0.2.12",
 ]
 all = [
   "kwneuro[hdbet,tractseg,noddi,combat]",


### PR DESCRIPTION
Reduces some of the noise we'll get from dependabot by consolidating its updates into fewer grouped PRs.

Also switch to monthly rather than weekly, for further grouping

Also switch to uv package ecosystem, since we have a uv.lock that dependabot needs to see.