### PR TITLE
Support multiple cache entries for the same function

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -317,6 +317,30 @@ with Cache(cache_dir="my_cache/sub-01", force=False) as cache:
 Each subject should use a distinct `cache_dir` to avoid collisions.
 `cache_dir` is created automatically if it does not exist.
 
+#### Cache layout
+
+Each argument combination has its own cache entry:
+
+```text
+cache_dir/
+  estimate_dti/
+    <argument-digest>/
+      estimate_dti.nii.gz
+      estimate_dti.params.json
+```
+
+The argument digest is the sha256 of canonical JSON containing the cache-format
+version, bound scalar arguments, and fingerprints of non-scalar inputs. The
+sidecar payload contains exactly the `version`, `scalars`, and `hashes` fields,
+with `version` set to `1`. Calling the same step with different arguments
+creates a sibling entry instead of overwriting an earlier result, so A, B, and
+then A again reuses the first entry. The sidecar is written last; an entry is
+complete only when it has a valid sidecar and every output declared by the cache
+protocol or `CacheSpec`.
+
+Flat cache files created by older versions are left in place but ignored. The
+first call recomputes them into the argument-keyed layout.
+
 #### The `@cacheable` decorator — two forms
 
 **Bare `@cacheable`**: use when the return type implements the cache protocol
@@ -365,8 +389,8 @@ ensuring consistency between hit and miss paths.
 
 #### Fingerprinting
 
-Each call's arguments are classified into two buckets stored in a sidecar file
-`{step_name}.params.json`:
+Each call's arguments are classified into two buckets stored in
+`cache_dir/<step-name>/<argument-digest>/<step-name>.params.json`:
 
 - **`"scalars"`** — `bool`, `int`, `float`, `str`, `None` values stored
   verbatim as human-readable JSON. Note: `None` is treated as a scalar, not
@@ -377,9 +401,11 @@ Each call's arguments are classified into two buckets stored in a sidecar file
   (recursively, field by field). This covers the full resource hierarchy (`Dwi`,
   `VolumeResource`, etc.) without those classes needing to know about caching.
 
-A mismatch in either section triggers a cache miss. Arguments of unrecognised
-types cannot be tracked and trigger a `UserWarning`; use
-`force={"step_name"}` to force recomputation when such an argument changes.
+The format version and two argument sections determine the call's argument
+digest. If no complete entry exists for that digest, the call is a cache miss;
+other argument combinations remain available. Arguments of unrecognised types
+cannot be tracked and trigger a `UserWarning`; use `force={"step_name"}` to
+force recomputation when such an argument changes.
 
 #### `force` parameter
 
@@ -390,16 +416,20 @@ Cache(cache_dir=..., force=True)  # recompute everything
 Cache(cache_dir=..., force={"estimate_noddi"})  # recompute only this step
 ```
 
+Forcing a call replaces its matching argument entry without removing entries
+for other argument combinations.
+
 #### `cache.status()`
 
 ```python
 cache.status([dwi.estimate_dti, dwi.estimate_noddi])
-# -> {"Dwi.estimate_dti": True, "Dwi.estimate_noddi": False}
+# -> {"Dwi.estimate_dti": 2, "Dwi.estimate_noddi": 0}
 ```
 
-Returns a `dict[str, bool]` mapping each step's `fn.__qualname__` to whether
-all its cached output files exist on disk. Non-decorated callables passed to
-`status()` are silently skipped.
+Returns a `dict[str, int]` mapping each step's `fn.__qualname__` to its number
+of complete cached argument entries. Incomplete entries with a missing or
+invalid sidecar or missing output are not counted. Non-decorated callables
+passed to `status()` are silently skipped.
 
 #### Thread / async safety
 

--- a/docs/tutorials/example-custom-step.md
+++ b/docs/tutorials/example-custom-step.md
@@ -86,7 +86,8 @@ CALL_COUNT = 0
 
 Outside a `Cache` context, `@cacheable` has no effect. Inside a context, the
 first call writes the result to disk, and later calls with the same inputs
-load the saved output.
+load the saved output. `Cache.status()` reports the number of complete
+argument entries for each step.
 
 
 ```python
@@ -111,27 +112,40 @@ with Cache(cache_dir, force={"high_intensity_mask"}):
 print(f"Executions after forced recompute: {CALL_COUNT}")
 ```
 
-    {'high_intensity_mask': True}
+    {'high_intensity_mask': 1}
     Executions after first cached call: 1
     Executions after cache hit: 1
     Cached output matches: True
     Executions after forced recompute: 2
 
 
-Changing a scalar parameter also changes the cache fingerprint, so the next
-call recomputes and stores a new result.
+Changing a scalar parameter creates another cache entry. The result for the
+original argument combination remains available.
 
 
 ```python
-with Cache(cache_dir):
+with Cache(cache_dir) as cache:
     lower_threshold_mask = high_intensity_mask(volume, threshold=0.4)
+    print(cache.status([high_intensity_mask]))
 
 print(f"Executions after parameter change: {CALL_COUNT}")
 print(f"Lower-threshold voxels: {int(lower_threshold_mask.get_array().sum())}")
+
+with Cache(cache_dir):
+    original_threshold_mask = high_intensity_mask(volume, threshold=0.6)
+
+print(f"Executions after reusing original arguments: {CALL_COUNT}")
+print(
+    "Original entry still matches: "
+    f"{np.array_equal(mask_1.get_array(), original_threshold_mask.get_array())}"
+)
 ```
 
+    {'high_intensity_mask': 2}
     Executions after parameter change: 3
     Lower-threshold voxels: 149
+    Executions after reusing original arguments: 3
+    Original entry still matches: True
 
 
 ## Interoperate with file-based external tools

--- a/docs/tutorials/example-pipeline.md
+++ b/docs/tutorials/example-pipeline.md
@@ -155,7 +155,7 @@ plt.tight_layout()
 plt.show()
 ```
 
-    Mask shape: (128, 128, 60), voxels in brain: 174687.0
+    Mask shape: (128, 128, 60), voxels in brain: 174771.0
 
 
 
@@ -403,14 +403,17 @@ print(f"Results saved to {output_dir.resolve()}")
 Wrapping pipeline steps in a `Cache` context manager enables automatic
 disk-based caching. Key behaviours:
 
-- **First run:** results are computed and saved to `cache_dir`.
-- **Subsequent runs:** results are loaded from disk, skipping the computation.
+- **First run:** results are computed and saved under
+  `cache_dir/<step_name>/<argument-digest>/`.
+- **Subsequent runs:** the same argument combination is loaded from disk,
+  skipping the computation.
 - **Scalar parameters** (`int`, `float`, `str`, `bool`) are stored as
-  human-readable JSON and fingerprinted — changing a value invalidates that
-  step's cache.
+  human-readable JSON and fingerprinted — changing a value creates another
+  cache entry without replacing the earlier one.
 - **Input data** (volumes, b-values, b-vectors, masks, response functions) are
-  sha256-fingerprinted — if the underlying data changes, the cache is
-  invalidated automatically.
+  sha256-fingerprinted — different input content gets a separate cache entry.
+- **Cache status:** `Cache.status()` reports how many complete argument
+  entries are available for each step.
 - **Forced recomputation:** pass `force={"step_name"}` or `force=True` to
   rerun a specific step or all steps regardless of cache state.
 
@@ -432,53 +435,41 @@ with Cache(cache_dir) as pc:
 ```python
 status = pc.status([Dti.estimate_dti, Noddi.estimate_noddi, compute_csd_peaks])
 print("Cache status:")
-for step, is_cached in status.items():
-    print(f"  {step}: {'cached' if is_cached else 'not cached'}")
+for step, entry_count in status.items():
+    print(f"  {step}: {entry_count} cached argument set(s)")
 ```
 
     Cache status:
-      Dti.estimate_dti: cached
-      Noddi.estimate_noddi: cached
-      compute_csd_peaks: cached
+      Dti.estimate_dti: 1 cached argument set(s)
+      Noddi.estimate_noddi: 1 cached argument set(s)
+      compute_csd_peaks: 1 cached argument set(s)
 
 
-Quick look at the `.params.json` file saved alongside each cached step.
-The sidecar has two sections:
+Each step directory contains one subdirectory per argument digest. The
+`.params.json` saved inside an entry records the cache format version
+plus two human-inspectable argument sections:
 
 - `scalars` — scalar parameters stored as human-readable JSON, so you can
   inspect exactly what values were used to produce the cached result.
 - `hashes` — sha256 fingerprints of non-scalar inputs (DWI volume,
   b-values, b-vectors, mask, response function, etc.). If the underlying data
-  changes between runs, the hash changes and the cache is invalidated.
+  changes between runs, it maps to another cache entry.
 
 
 ```python
 import json
 
-print("Files in cache_dir:")
-for f in sorted(cache_dir.iterdir()):
-    print(f"  {f.name}")
+step_dir = cache_dir / "estimate_dti"
+entry_dir = next(path for path in sorted(step_dir.iterdir()) if path.is_dir())
 
-print("\nestimate_dti.params.json:")
-sidecar = json.loads((cache_dir / "estimate_dti.params.json").read_text())
-print(json.dumps(sidecar, indent=2))
+print("Files for one estimate_dti argument set:")
+print(f"  {step_dir.name}/")
+print(f"    {entry_dir.name}/")
+for path in sorted(entry_dir.iterdir()):
+    print(f"      {path.name}")
+
+params_path = entry_dir / "estimate_dti.params.json"
+print(f"\n{params_path.relative_to(cache_dir)}:")
+params = json.loads(params_path.read_text())
+print(json.dumps(params, indent=2))
 ```
-
-    Files in cache_dir:
-      compute_csd_peaks.params.json
-      csd_peak_dirs.nii.gz
-      csd_peak_values.nii.gz
-      estimate_dti.nii.gz
-      estimate_dti.params.json
-      estimate_noddi.nii.gz
-      estimate_noddi.params.json
-      estimate_noddi_directions.nii.gz
-    
-    estimate_dti.params.json:
-    {
-      "hashes": {
-        "dwi": "a0b14d69557b8bdba79063cd935673b8c114ffaf1c3756b87c2c930d905abc6a",
-        "mask": "454054019b2fb1265fbeca5db8fb65b1701390a75d443c974e4f9896f8a71953"
-      }
-    }
-

--- a/notebooks/example-custom-step.py
+++ b/notebooks/example-custom-step.py
@@ -95,7 +95,8 @@ CALL_COUNT = 0
 #
 # Outside a `Cache` context, `@cacheable` has no effect. Inside a context, the
 # first call writes the result to disk, and later calls with the same inputs
-# load the saved output.
+# load the saved output. `Cache.status()` reports the number of complete
+# argument entries for each step.
 
 # %%
 tmpdir = TemporaryDirectory()
@@ -119,15 +120,25 @@ with Cache(cache_dir, force={"high_intensity_mask"}):
 print(f"Executions after forced recompute: {CALL_COUNT}")
 
 # %% [markdown]
-# Changing a scalar parameter also changes the cache fingerprint, so the next
-# call recomputes and stores a new result.
+# Changing a scalar parameter creates another cache entry. The result for the
+# original argument combination remains available.
 
 # %%
-with Cache(cache_dir):
+with Cache(cache_dir) as cache:
     lower_threshold_mask = high_intensity_mask(volume, threshold=0.4)
+    print(cache.status([high_intensity_mask]))
 
 print(f"Executions after parameter change: {CALL_COUNT}")
 print(f"Lower-threshold voxels: {int(lower_threshold_mask.get_array().sum())}")
+
+with Cache(cache_dir):
+    original_threshold_mask = high_intensity_mask(volume, threshold=0.6)
+
+print(f"Executions after reusing original arguments: {CALL_COUNT}")
+print(
+    "Original entry still matches: "
+    f"{np.array_equal(mask_1.get_array(), original_threshold_mask.get_array())}"
+)
 
 # %% [markdown]
 # ## Interoperate with file-based external tools

--- a/notebooks/example-pipeline.py
+++ b/notebooks/example-pipeline.py
@@ -355,14 +355,17 @@ print(f"Results saved to {output_dir.resolve()}")
 # Wrapping pipeline steps in a `Cache` context manager enables automatic
 # disk-based caching. Key behaviours:
 #
-# - **First run:** results are computed and saved to `cache_dir`.
-# - **Subsequent runs:** results are loaded from disk, skipping the computation.
+# - **First run:** results are computed and saved under
+#   `cache_dir/<step_name>/<argument-digest>/`.
+# - **Subsequent runs:** the same argument combination is loaded from disk,
+#   skipping the computation.
 # - **Scalar parameters** (`int`, `float`, `str`, `bool`) are stored as
-#   human-readable JSON and fingerprinted — changing a value invalidates that
-#   step's cache.
+#   human-readable JSON and fingerprinted — changing a value creates another
+#   cache entry without replacing the earlier one.
 # - **Input data** (volumes, b-values, b-vectors, masks, response functions) are
-#   sha256-fingerprinted — if the underlying data changes, the cache is
-#   invalidated automatically.
+#   sha256-fingerprinted — different input content gets a separate cache entry.
+# - **Cache status:** `Cache.status()` reports how many complete argument
+#   entries are available for each step.
 # - **Forced recomputation:** pass `force={"step_name"}` or `force=True` to
 #   rerun a specific step or all steps regardless of cache state.
 
@@ -381,26 +384,33 @@ with Cache(cache_dir) as pc:
 # %%
 status = pc.status([Dti.estimate_dti, Noddi.estimate_noddi, compute_csd_peaks])
 print("Cache status:")
-for step, is_cached in status.items():
-    print(f"  {step}: {'cached' if is_cached else 'not cached'}")
+for step, entry_count in status.items():
+    print(f"  {step}: {entry_count} cached argument set(s)")
 
 # %% [markdown]
-# Quick look at the `.params.json` file saved alongside each cached step.
-# The sidecar has two sections:
+# Each step directory contains one subdirectory per argument digest. The
+# `.params.json` saved inside an entry records the cache format version
+# plus two human-inspectable argument sections:
 #
 # - `scalars` — scalar parameters stored as human-readable JSON, so you can
 #   inspect exactly what values were used to produce the cached result.
 # - `hashes` — sha256 fingerprints of non-scalar inputs (DWI volume,
 #   b-values, b-vectors, mask, response function, etc.). If the underlying data
-#   changes between runs, the hash changes and the cache is invalidated.
+#   changes between runs, it maps to another cache entry.
 
-# %%
+# %% tags=["remove-output"]
 import json
 
-print("Files in cache_dir:")
-for f in sorted(cache_dir.iterdir()):
-    print(f"  {f.name}")
+step_dir = cache_dir / "estimate_dti"
+entry_dir = next(path for path in sorted(step_dir.iterdir()) if path.is_dir())
 
-print("\nestimate_dti.params.json:")
-sidecar = json.loads((cache_dir / "estimate_dti.params.json").read_text())
-print(json.dumps(sidecar, indent=2))
+print("Files for one estimate_dti argument set:")
+print(f"  {step_dir.name}/")
+print(f"    {entry_dir.name}/")
+for path in sorted(entry_dir.iterdir()):
+    print(f"      {path.name}")
+
+params_path = entry_dir / "estimate_dti.params.json"
+print(f"\n{params_path.relative_to(cache_dir)}:")
+params = json.loads(params_path.read_text())
+print(json.dumps(params, indent=2))

--- a/src/kwneuro/cache.py
+++ b/src/kwneuro/cache.py
@@ -24,6 +24,7 @@ _active_cache: contextvars.ContextVar[Cache | None] = contextvars.ContextVar(
 # Scalar types are stored verbatim as human-readable JSON in the params sidecar.
 # All other argument types go through content fingerprinting (see _compute_fingerprint).
 _SCALAR_TYPES = (bool, int, float, str, type(None))
+_CACHE_FORMAT_VERSION = 1
 
 
 @dataclass
@@ -35,13 +36,13 @@ class CacheSpec(Generic[T]):
     """
 
     files: list[str]
-    """Output filenames relative to the cache directory."""
+    """Output filenames relative to the current cache-entry directory."""
 
     save: Callable[[T, Path], None]
-    """Callable that persists the result to the cache directory."""
+    """Callable that persists the result to the current cache-entry directory."""
 
     load: Callable[[Path], T]
-    """Callable that reconstructs the result from the cache directory."""
+    """Callable that reconstructs the result from the current cache-entry directory."""
 
     step_name: str = ""
     """Step name used to identify this step in the params sidecar. Defaults to the decorated function name."""
@@ -60,13 +61,14 @@ class Cache:
     """Context manager that activates caching for all ``@cacheable``-decorated functions.
 
     Scalar arguments and imaging data arguments are fingerprinted automatically.
-    Changes to either trigger a cache miss on the next run. Arguments that cannot
-    be fingerprinted issue a UserWarning. Each subject should use a distinct
-    cache_dir to avoid races.
+    Each distinct argument set is stored in its own cache entry, so results from
+    multiple calls to the same function remain available. Arguments that cannot be
+    fingerprinted issue a UserWarning. Each subject should use a distinct cache_dir
+    to avoid races.
     """
 
     cache_dir: Path
-    """Directory where cached outputs and per-step sidecar files are stored. Created automatically."""
+    """Root directory containing per-step, per-invocation cache entries. Created automatically."""
 
     force: bool | set[str] = field(default=False)
     """Cache bypass control. False uses all cached outputs, True recomputes everything,
@@ -95,6 +97,15 @@ class Cache:
             return step_name in self.force
         return bool(self.force)
 
+    def _entry_dir(
+        self,
+        step_name: str,
+        scalars: dict[str, Any] | None = None,
+        hashes: dict[str, str] | None = None,
+    ) -> Path:
+        """Return the directory for one step invocation."""
+        return self.cache_dir / step_name / _compute_cache_key(scalars, hashes)
+
     def is_cached(
         self,
         step_name: str,
@@ -102,15 +113,15 @@ class Cache:
         scalars: dict[str, Any] | None = None,
         hashes: dict[str, str] | None = None,
     ) -> bool:
-        """Return True when all output files exist, the step is not forced, and the stored fingerprint matches.
+        """Return True when a complete entry exists for this step invocation.
 
-        The sidecar file stores two sections: "scalars" for human-readable scalar argument
-        values and "hashes" for sha256 content fingerprints. A mismatch in either section,
-        or a missing sidecar when params are expected, is treated as a cache miss.
+        The sidecar stores human-readable scalar arguments and sha256 content
+        fingerprints. Missing outputs, a missing or malformed sidecar, or a
+        sidecar that does not match the requested invocation is a cache miss.
 
         Args:
             step_name: Name of the cache step, used to locate the sidecar file.
-            files: Output filenames relative to cache_dir that must all exist for a cache hit.
+            files: Output filenames relative to the invocation directory that must all exist.
             scalars: Scalar argument values to compare against the stored sidecar, or None.
             hashes: Content fingerprints to compare against the stored sidecar, or None.
 
@@ -118,41 +129,40 @@ class Cache:
         """
         if self.is_forced(step_name):
             return False
-        if not all((self.cache_dir / f).exists() for f in files):
-            return False
-        if scalars or hashes:
-            params_file = self.cache_dir / f"{step_name}.params.json"
-            if not params_file.exists():
-                return False
-            try:
-                stored = json.loads(params_file.read_text(encoding="utf-8"))
-                # Compare the scalars section (human-readable parameter values).
-                if scalars and stored.get("scalars") != scalars:
-                    return False
-                # Compare the hashes section (content fingerprints for imaging data).
-                if hashes and stored.get("hashes") != hashes:
-                    return False
-            except Exception:  # pylint: disable=broad-exception-caught
-                return False
-        return True
+        entry_dir = self._entry_dir(step_name, scalars, hashes)
+        expected_params = _build_cache_params(scalars, hashes)
+        return _entry_is_complete(
+            entry_dir,
+            step_name,
+            files,
+            expected_params=expected_params,
+        )
 
-    def status(self, steps: list[Callable[..., Any]]) -> dict[str, bool]:
-        """Return a mapping of each step's qualified name to whether all its cached output files exist.
+    def status(self, steps: list[Callable[..., Any]]) -> dict[str, int]:
+        """Return the number of complete cached invocations for each step.
 
         Non-decorated callables in steps are silently skipped.
 
         Args:
             steps: List of cacheable-decorated functions to check.
 
-        Returns: Dict mapping fn.__qualname__ to True if all cached outputs exist, False otherwise.
+        Returns: Dict mapping fn.__qualname__ to its number of complete cache entries.
         """
-        result: dict[str, bool] = {}
+        result: dict[str, int] = {}
         for fn in steps:
             info: _CacheInfo | None = getattr(fn, "_cache_info", None)
             if info is None:
                 continue
             files = info.get_files(info.step_name)
-            result[fn.__qualname__] = all((self.cache_dir / f).exists() for f in files)
+            step_dir = self.cache_dir / info.step_name
+            if not step_dir.is_dir():
+                result[fn.__qualname__] = 0
+                continue
+            result[fn.__qualname__] = sum(
+                _entry_is_complete(entry_dir, info.step_name, files)
+                for entry_dir in step_dir.iterdir()
+                if entry_dir.is_dir()
+            )
         return result
 
 
@@ -349,16 +359,83 @@ def _extract_params(
     return scalars or None, hashes or None
 
 
+def _build_cache_params(
+    scalars: dict[str, Any] | None,
+    hashes: dict[str, str] | None,
+) -> dict[str, Any]:
+    """Build the canonical sidecar payload for one cached invocation."""
+    return {
+        "version": _CACHE_FORMAT_VERSION,
+        "scalars": scalars or {},
+        "hashes": hashes or {},
+    }
+
+
+def _cache_key_from_params(params: dict[str, Any]) -> str:
+    """Compute the cache-entry key for a canonical sidecar payload."""
+    encoded = json.dumps(params, sort_keys=True, separators=(",", ":")).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _compute_cache_key(
+    scalars: dict[str, Any] | None,
+    hashes: dict[str, str] | None,
+) -> str:
+    """Compute the cache-entry key for bound scalar values and input hashes."""
+    return _cache_key_from_params(_build_cache_params(scalars, hashes))
+
+
+def _valid_cache_params(data: Any) -> bool:
+    """Return whether data has the current cache-sidecar schema."""
+    return (
+        isinstance(data, dict)
+        and set(data) == {"version", "scalars", "hashes"}
+        and isinstance(data["version"], int)
+        and not isinstance(data["version"], bool)
+        and data["version"] == _CACHE_FORMAT_VERSION
+        and isinstance(data["scalars"], dict)
+        and isinstance(data["hashes"], dict)
+        and all(isinstance(k, str) for k in data["scalars"])
+        and all(
+            isinstance(k, str) and isinstance(v, str) for k, v in data["hashes"].items()
+        )
+    )
+
+
+def _entry_is_complete(
+    entry_dir: Path,
+    step_name: str,
+    files: list[str],
+    expected_params: dict[str, Any] | None = None,
+) -> bool:
+    """Return whether an entry has valid parameters and every declared output."""
+    if not all((entry_dir / filename).exists() for filename in files):
+        return False
+
+    params_file = entry_dir / f"{step_name}.params.json"
+    if not params_file.exists():
+        return False
+    try:
+        stored = json.loads(params_file.read_text(encoding="utf-8"))
+    except Exception:  # pylint: disable=broad-exception-caught
+        return False
+    if not _valid_cache_params(stored):
+        return False
+    if expected_params is not None and stored != expected_params:
+        return False
+    return entry_dir.name == _cache_key_from_params(stored)
+
+
 def _save_params(
     cache_dir: Path,
     step_name: str,
     scalars: dict[str, Any] | None,
     hashes: dict[str, str] | None,
 ) -> None:
-    """Write scalar params and content hashes to {step_name}.params.json.
+    """Write the canonical invocation parameters to {step_name}.params.json.
 
-    The sidecar stores two sections: "scalars" for human-readable scalar argument values
-    and "hashes" for sha256 content fingerprints. No file is written if both are empty.
+    The sidecar is written after the outputs and acts as the entry's completion
+    marker. It is created even when the decorated function has no arguments.
 
     Args:
         cache_dir: Directory where the sidecar file is written.
@@ -366,15 +443,9 @@ def _save_params(
         scalars: Scalar argument values to persist, or None.
         hashes: Content fingerprints to persist, or None.
     """
-    if not scalars and not hashes:
-        return
-    data: dict[str, Any] = {}
-    if scalars:
-        data["scalars"] = scalars
-    if hashes:
-        data["hashes"] = hashes
+    data = _build_cache_params(scalars, hashes)
     (cache_dir / f"{step_name}.params.json").write_text(
-        json.dumps(data, sort_keys=True), encoding="utf-8"
+        f"{json.dumps(data, indent=2, sort_keys=True)}\n", encoding="utf-8"
     )
 
 
@@ -382,8 +453,9 @@ def cacheable(fn_or_spec: Callable[..., Any] | CacheSpec[Any]) -> Any:
     """Decorator that adds transparent caching when a Cache context is active.
 
     Outside a ``with Cache(...)`` block the function runs normally with no overhead.
-    Scalar and dataclass arguments are fingerprinted automatically; a change in either
-    causes a cache miss. Arguments that cannot be fingerprinted trigger a UserWarning.
+    Scalar and dataclass arguments are fingerprinted automatically. Each distinct
+    argument set gets its own cache entry. Arguments that cannot be fingerprinted
+    trigger a UserWarning.
 
     Can be used in two ways. As a bare decorator when the return type implements
     the cache protocol (_cache_files, _cache_save, _cache_load)::
@@ -414,14 +486,17 @@ def cacheable(fn_or_spec: Callable[..., Any] | CacheSpec[Any]) -> Any:
                     return fn(*args, **kwargs)
                 # Classify arguments into scalars and content hashes.
                 scalars, hashes = _extract_params(fn, args, kwargs)
+                entry_dir = cache._entry_dir(step_name, scalars, hashes)
                 if cache.is_cached(step_name, spec.files, scalars, hashes):
                     # All output files exist and the fingerprint matches — load from disk.
-                    return spec.load(cache.cache_dir)
+                    return spec.load(entry_dir)
                 # Cache miss: run the function, persist the outputs, save the fingerprint.
                 result = fn(*args, **kwargs)
-                spec.save(result, cache.cache_dir)
-                _save_params(cache.cache_dir, step_name, scalars, hashes)
-                return spec.load(cache.cache_dir)
+                entry_dir.mkdir(parents=True, exist_ok=True)
+                (entry_dir / f"{step_name}.params.json").unlink(missing_ok=True)
+                spec.save(result, entry_dir)
+                _save_params(entry_dir, step_name, scalars, hashes)
+                return spec.load(entry_dir)
 
             _wrapper._cache_info = _CacheInfo(  # type: ignore[attr-defined]
                 step_name=step_name,
@@ -464,15 +539,18 @@ def cacheable(fn_or_spec: Callable[..., Any] | CacheSpec[Any]) -> Any:
         rt = _get_return_type()
         # Classify arguments into scalars and content hashes.
         scalars, hashes = _extract_params(fn, args, kwargs)
+        entry_dir = cache._entry_dir(step_name, scalars, hashes)
         files = rt._cache_files(step_name)
         if cache.is_cached(step_name, files, scalars, hashes):
             # All output files exist and the fingerprint matches — load from disk.
-            return rt._cache_load(cache.cache_dir, step_name)
+            return rt._cache_load(entry_dir, step_name)
         # Cache miss: run the function, persist the output, save the fingerprint.
         result = fn(*args, **kwargs)
-        result._cache_save(cache.cache_dir, step_name)
-        _save_params(cache.cache_dir, step_name, scalars, hashes)
-        return rt._cache_load(cache.cache_dir, step_name)
+        entry_dir.mkdir(parents=True, exist_ok=True)
+        (entry_dir / f"{step_name}.params.json").unlink(missing_ok=True)
+        result._cache_save(entry_dir, step_name)
+        _save_params(entry_dir, step_name, scalars, hashes)
+        return rt._cache_load(entry_dir, step_name)
 
     _wrapper._cache_info = _CacheInfo(  # type: ignore[attr-defined]
         step_name=step_name,

--- a/src/kwneuro/tractseg.py
+++ b/src/kwneuro/tractseg.py
@@ -1,11 +1,10 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
-from kwneuro.cache import _active_cache, _compute_fingerprint, _save_params
+from kwneuro.cache import cacheable
 from kwneuro.csd import combine_csd_peaks_to_vector_volume, compute_csd_peaks
-from kwneuro.io import NiftiVolumeResource
 from kwneuro.resource import ResponseFunctionResource, VolumeResource
 from kwneuro.util import create_estimate_volume_resource
 
@@ -28,6 +27,7 @@ def _call_tractseg(data: np.ndarray, output_type: str) -> np.ndarray:
     return run_tractseg(data=data, output_type=output_type)
 
 
+@cacheable
 def extract_tractseg(
     dwi: Dwi,
     mask: VolumeResource,
@@ -56,28 +56,6 @@ def extract_tractseg(
         for endings_segmentation:   [x, y, z, 2*nr_of_bundles]
         for TOM:                    [x, y, z, 3*nr_of_bundles]
     """
-    # Inline cache check — uses a dynamic filename so a decorator cannot be used.
-    _cache = _active_cache.get()
-    _cache_file = f"tractseg_{output_type}.nii.gz"
-    _scalars: dict[str, Any] | None = None
-    _hashes: dict[str, str] | None = None
-    if _cache is not None:
-        _scalars = {"output_type": output_type}
-        h: dict[str, str] = {}
-        for name, val in [
-            ("dwi", dwi),
-            ("mask", mask),
-            ("response", response),
-            ("csd_peaks", csd_peaks),
-        ]:
-            fp = _compute_fingerprint(val)
-            if fp is not None:
-                h[name] = fp
-        _hashes = h or None
-        if _cache.is_cached("extract_tractseg", [_cache_file], _scalars, _hashes):
-            logging.info("extract_tractseg: cache hit (%s)", output_type)
-            return NiftiVolumeResource(_cache.cache_dir / _cache_file)
-
     if csd_peaks is None:
         # Compute CSD peaks (MRtrix3 convention: 3 peaks).
         # compute_csd_peaks is @cacheable, so it uses _cache automatically.
@@ -97,15 +75,8 @@ def extract_tractseg(
         data=csd_peaks_vector.get_array(), output_type=output_type
     )
 
-    result = create_estimate_volume_resource(
+    return create_estimate_volume_resource(
         array=segmentation,
         reference_volume=dwi.volume,
         intent_name="TRACTSEG",
     )
-
-    if _cache is not None:
-        logging.info("extract_tractseg: saving cache (%s)", output_type)
-        _save_params(_cache.cache_dir, "extract_tractseg", _scalars, _hashes)
-        return NiftiVolumeResource.save(result, _cache.cache_dir / _cache_file)
-
-    return result

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-from dataclasses import dataclass
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -15,6 +14,7 @@ from kwneuro.cache import (
     CacheSpec,
     _active_cache,
     _compute_fingerprint,
+    _save_params,
     cacheable,
 )
 from kwneuro.csd import compute_csd_peaks
@@ -29,22 +29,34 @@ from kwneuro.resource import (
 )
 
 
-@dataclass
-class _CacheableText:
-    """Minimal result type for exercising bare @cacheable behavior."""
+def _write_cache_entry(
+    cache: Cache,
+    step_name: str,
+    files: list[str],
+    scalars: dict[str, object] | None = None,
+    hashes: dict[str, str] | None = None,
+    *,
+    write_params: bool = True,
+) -> Path:
+    """Create a cache entry for direct Cache.is_cached tests."""
+    entry_dir = cache._entry_dir(step_name, scalars, hashes)
+    entry_dir.mkdir(parents=True)
+    for filename in files:
+        path = entry_dir / filename
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("result")
+    if write_params:
+        _save_params(entry_dir, step_name, scalars, hashes)
+    return entry_dir
 
-    value: str
 
-    @classmethod
-    def _cache_files(cls, step_name: str) -> list[str]:
-        return [f"{step_name}.txt"]
-
-    def _cache_save(self, cache_dir: Path, step_name: str) -> None:
-        (cache_dir / f"{step_name}.txt").write_text(self.value)
-
-    @classmethod
-    def _cache_load(cls, cache_dir: Path, step_name: str) -> _CacheableText:
-        return cls((cache_dir / f"{step_name}.txt").read_text())
+def _only_cache_entry(cache_dir: Path, step_name: str) -> Path:
+    """Return the only keyed entry for a test step."""
+    entries = [path for path in (cache_dir / step_name).iterdir() if path.is_dir()]
+    assert len(entries) == 1
+    assert len(entries[0].name) == 64
+    int(entries[0].name, 16)
+    return entries[0]
 
 
 @pytest.fixture
@@ -135,57 +147,82 @@ def test_is_cached_missing_file(tmp_path: Path) -> None:
 
 
 def test_is_cached_all_files_present(tmp_path: Path) -> None:
-    (tmp_path / "out.txt").write_text("x")
     pc = Cache(tmp_path, force=False)
+    _write_cache_entry(pc, "step", ["out.txt"])
     assert pc.is_cached("step", ["out.txt"])
 
 
 def test_is_cached_forced_overrides_present(tmp_path: Path) -> None:
-    (tmp_path / "out.txt").write_text("x")
+    _write_cache_entry(Cache(tmp_path), "step", ["out.txt"])
     pc = Cache(tmp_path, force=True)
     assert not pc.is_cached("step", ["out.txt"])
 
 
 def test_is_cached_scalars_match(tmp_path: Path) -> None:
-    (tmp_path / "out.txt").write_text("x")
-    (tmp_path / "step.params.json").write_text(
-        json.dumps({"scalars": {"x": 1}}, sort_keys=True)
-    )
     pc = Cache(tmp_path)
+    _write_cache_entry(pc, "step", ["out.txt"], scalars={"x": 1})
     assert pc.is_cached("step", ["out.txt"], scalars={"x": 1})
 
 
 def test_is_cached_scalars_mismatch(tmp_path: Path) -> None:
-    (tmp_path / "out.txt").write_text("x")
-    (tmp_path / "step.params.json").write_text(
-        json.dumps({"scalars": {"x": 1}}, sort_keys=True)
-    )
     pc = Cache(tmp_path)
+    _write_cache_entry(pc, "step", ["out.txt"], scalars={"x": 1})
     assert not pc.is_cached("step", ["out.txt"], scalars={"x": 99})
 
 
 def test_is_cached_params_file_missing_is_miss(tmp_path: Path) -> None:
-    (tmp_path / "out.txt").write_text("x")
     pc = Cache(tmp_path)
+    _write_cache_entry(
+        pc,
+        "step",
+        ["out.txt"],
+        scalars={"x": 1},
+        write_params=False,
+    )
     assert not pc.is_cached("step", ["out.txt"], scalars={"x": 1})
 
 
 def test_is_cached_hashes_match(tmp_path: Path) -> None:
-    (tmp_path / "out.txt").write_text("x")
-    (tmp_path / "step.params.json").write_text(
-        json.dumps({"hashes": {"arr": "abc123"}}, sort_keys=True)
-    )
     pc = Cache(tmp_path)
+    _write_cache_entry(pc, "step", ["out.txt"], hashes={"arr": "abc123"})
     assert pc.is_cached("step", ["out.txt"], hashes={"arr": "abc123"})
 
 
 def test_is_cached_hashes_mismatch(tmp_path: Path) -> None:
-    (tmp_path / "out.txt").write_text("x")
-    (tmp_path / "step.params.json").write_text(
-        json.dumps({"hashes": {"arr": "abc123"}}, sort_keys=True)
-    )
     pc = Cache(tmp_path)
+    _write_cache_entry(pc, "step", ["out.txt"], hashes={"arr": "abc123"})
     assert not pc.is_cached("step", ["out.txt"], hashes={"arr": "different"})
+
+
+def test_legacy_flat_entry_is_recomputed_once(tmp_path: Path) -> None:
+    """A legacy entry is left untouched while a reusable keyed entry is created."""
+    (tmp_path / "out.txt").write_text("legacy")
+    (tmp_path / "fn.params.json").write_text(
+        json.dumps({"scalars": {"value": 1}}), encoding="utf-8"
+    )
+    calls: list[int] = []
+
+    def _save(result: str, cache_dir: Path) -> None:
+        (cache_dir / "out.txt").write_text(result)
+
+    @cacheable(  # type: ignore[untyped-decorator]
+        CacheSpec(
+            files=["out.txt"],
+            save=_save,
+            load=lambda cache_dir: (cache_dir / "out.txt").read_text(),
+        )
+    )
+    def fn(value: int) -> str:
+        calls.append(value)
+        return f"new-{value}"
+
+    with Cache(tmp_path) as cache:
+        assert fn(1) == "new-1"
+        assert fn(1) == "new-1"
+
+    assert calls == [1]
+    assert (tmp_path / "out.txt").read_text() == "legacy"
+    assert cache.status([fn])[fn.__qualname__] == 1
 
 
 # ---------------------------------------------------------------------------
@@ -272,21 +309,28 @@ def test_cacheable_no_op_outside_context(dwi3: Dwi) -> None:
 def test_cacheable_reuses_all_argument_variants(tmp_path: Path) -> None:
     """Results for multiple inputs remain cached across Cache contexts."""
     calls: list[int] = []
+    array_a = np.ones((2, 2, 2), dtype=np.float32)
+    array_b = np.full((2, 2, 2), 2, dtype=np.float32)
 
-    @cacheable  # type: ignore[untyped-decorator]
-    def fn(value: int) -> _CacheableText:
-        calls.append(value)
-        return _CacheableText(str(value))
-
-    with Cache(tmp_path):
-        assert fn(1).value == "1"
-        assert fn(2).value == "2"
+    @cacheable
+    def fn(array: np.ndarray) -> InMemoryVolumeResource:
+        calls.append(int(array[0, 0, 0]))
+        return InMemoryVolumeResource(array=array.copy(), affine=np.eye(4))
 
     with Cache(tmp_path):
-        assert fn(1).value == "1"
-        assert fn(2).value == "2"
+        result_a = fn(array_a)
+        result_b = fn(array_b)
+
+    # Cached results are lazy disk resources, so their paths must remain independent.
+    assert np.array_equal(result_a.get_array(), array_a)
+    assert np.array_equal(result_b.get_array(), array_b)
+
+    with Cache(tmp_path):
+        assert np.array_equal(fn(array_a).get_array(), array_a)
+        assert np.array_equal(fn(array_b).get_array(), array_b)
 
     assert calls == [1, 2]
+    assert Cache(tmp_path).status([fn])[fn.__qualname__] == 2
 
 
 def test_cacheable_reuses_earlier_argument_variant_with_cache_spec(
@@ -317,23 +361,85 @@ def test_cacheable_reuses_earlier_argument_variant_with_cache_spec(
     assert calls == [1, 2]
 
 
+def test_cacheable_equivalent_call_syntax_reuses_entry(tmp_path: Path) -> None:
+    """Positional, keyword, and explicit-default calls share one cache entry."""
+    calls: list[tuple[int, int]] = []
+
+    def _save(result: str, cache_dir: Path) -> None:
+        (cache_dir / "out.txt").write_text(result)
+
+    @cacheable(  # type: ignore[untyped-decorator]
+        CacheSpec(
+            files=["out.txt"],
+            save=_save,
+            load=lambda cache_dir: (cache_dir / "out.txt").read_text(),
+        )
+    )
+    def fn(value: int, scale: int = 2) -> str:
+        calls.append((value, scale))
+        return str(value * scale)
+
+    with Cache(tmp_path) as cache:
+        assert fn(3) == "6"
+        assert fn(value=3) == "6"
+        assert fn(3, scale=2) == "6"
+
+    assert calls == [(3, 2)]
+    assert cache.status([fn])[fn.__qualname__] == 1
+
+
+def test_force_recomputes_only_requested_argument_set(tmp_path: Path) -> None:
+    """Forcing A replaces A without evicting the cached result for B."""
+    calls: list[int] = []
+    call_counts = {1: 0, 2: 0}
+
+    def _save(result: str, cache_dir: Path) -> None:
+        (cache_dir / "out.txt").write_text(result)
+
+    @cacheable(  # type: ignore[untyped-decorator]
+        CacheSpec(
+            files=["out.txt"],
+            save=_save,
+            load=lambda cache_dir: (cache_dir / "out.txt").read_text(),
+        )
+    )
+    def fn(value: int) -> str:
+        calls.append(value)
+        call_counts[value] += 1
+        return f"{value}:{call_counts[value]}"
+
+    with Cache(tmp_path):
+        assert fn(1) == "1:1"
+        assert fn(2) == "2:1"
+
+    with Cache(tmp_path, force={"fn"}):
+        assert fn(1) == "1:2"
+
+    with Cache(tmp_path) as cache:
+        assert fn(1) == "1:2"
+        assert fn(2) == "2:1"
+
+    assert calls == [1, 2, 1]
+    assert cache.status([fn])[fn.__qualname__] == 2
+
+
 # ---------------------------------------------------------------------------
 # Cache.status
 # ---------------------------------------------------------------------------
 
 
-def test_status_missing_shows_false(tmp_path: Path) -> None:
+def test_status_missing_shows_zero(tmp_path: Path) -> None:
     pc = Cache(tmp_path)
     result = pc.status([Dti.estimate_dti])
-    assert result["Dti.estimate_dti"] is False
+    assert result["Dti.estimate_dti"] == 0
 
 
-def test_status_present_shows_true(dwi3: Dwi, tmp_path: Path) -> None:
+def test_status_present_shows_one(dwi3: Dwi, tmp_path: Path) -> None:
     pc = Cache(tmp_path)
     with pc:
         dwi3.estimate_dti()
     result = pc.status([Dti.estimate_dti])
-    assert result["Dti.estimate_dti"] is True
+    assert result["Dti.estimate_dti"] == 1
 
 
 def test_status_non_cacheable_skipped(tmp_path: Path) -> None:
@@ -345,13 +451,41 @@ def test_status_non_cacheable_skipped(tmp_path: Path) -> None:
 
 
 def test_status_multiple_steps(dwi3: Dwi, tmp_path: Path) -> None:
-    """status reflects which steps have been cached and which have not."""
+    """status reports the complete entry count for each cached step."""
     pc = Cache(tmp_path)
     with pc:
         dwi3.estimate_dti()
     result = pc.status([Dti.estimate_dti, Noddi.estimate_noddi])
-    assert result["Dti.estimate_dti"] is True
-    assert result["Noddi.estimate_noddi"] is False
+    assert result["Dti.estimate_dti"] == 1
+    assert result["Noddi.estimate_noddi"] == 0
+
+
+def test_status_counts_only_complete_entries(tmp_path: Path) -> None:
+    """Entries with a missing output or malformed sidecar are not counted."""
+
+    def _save(result: str, cache_dir: Path) -> None:
+        (cache_dir / "out.txt").write_text(result)
+
+    @cacheable(  # type: ignore[untyped-decorator]
+        CacheSpec(
+            files=["out.txt"],
+            save=_save,
+            load=lambda cache_dir: (cache_dir / "out.txt").read_text(),
+        )
+    )
+    def fn(value: int) -> str:
+        return str(value)
+
+    with Cache(tmp_path) as cache:
+        fn(1)
+        fn(2)
+        fn(3)
+
+    entries = sorted((tmp_path / "fn").iterdir())
+    (entries[0] / "out.txt").unlink()
+    (entries[1] / "fn.params.json").write_text("not json")
+
+    assert cache.status([fn])[fn.__qualname__] == 1
 
 
 # ---------------------------------------------------------------------------
@@ -367,8 +501,9 @@ def test_estimate_dti_with_caching(dwi3: Dwi, tmp_path: Path) -> None:
 
     assert np.allclose(dti.volume.get_affine(), dwi3.volume.get_affine())
     assert dti.volume.get_array().shape[:3] == (3, 4, 5)
-    assert (tmp_path / "estimate_dti.nii.gz").exists()
-    assert pc.status([Dti.estimate_dti])["Dti.estimate_dti"] is True
+    entry_dir = _only_cache_entry(tmp_path, "estimate_dti")
+    assert (entry_dir / "estimate_dti.nii.gz").exists()
+    assert pc.status([Dti.estimate_dti])["Dti.estimate_dti"] == 1
 
     # Second call returns the same result loaded from cache
     with pc:
@@ -429,9 +564,10 @@ def test_estimate_noddi_with_caching(dwi3: Dwi, mocker, tmp_path: Path) -> None:
     assert np.allclose(noddi.volume.get_array(), mock_ae.RESULTS["MAPs"])
     assert np.allclose(noddi.directions.get_array(), mock_ae.RESULTS["DIRs"])
     assert np.allclose(noddi.volume.get_affine(), dwi3.volume.get_affine())
-    assert (tmp_path / "estimate_noddi.nii.gz").exists()
-    assert (tmp_path / "estimate_noddi_directions.nii.gz").exists()
-    assert pc.status([Noddi.estimate_noddi])["Noddi.estimate_noddi"] is True
+    entry_dir = _only_cache_entry(tmp_path, "estimate_noddi")
+    assert (entry_dir / "estimate_noddi.nii.gz").exists()
+    assert (entry_dir / "estimate_noddi_directions.nii.gz").exists()
+    assert pc.status([Noddi.estimate_noddi])["Noddi.estimate_noddi"] == 1
 
     # Second call loads from cache — AMICO fit is not re-invoked
     mock_ae.fit.reset_mock()
@@ -514,9 +650,10 @@ def test_compute_csd_peaks_with_caching(dwi3: Dwi, mocker, tmp_path: Path) -> No
     assert np.allclose(peak_values.get_array(), mock_peaks.peak_values)
 
     # Cache files (fixed names from CacheSpec) exist and status reports cached
-    assert (tmp_path / "csd_peak_dirs.nii.gz").exists()
-    assert (tmp_path / "csd_peak_values.nii.gz").exists()
-    assert pc.status([compute_csd_peaks])["compute_csd_peaks"] is True
+    entry_dir = _only_cache_entry(tmp_path, "compute_csd_peaks")
+    assert (entry_dir / "csd_peak_dirs.nii.gz").exists()
+    assert (entry_dir / "csd_peak_values.nii.gz").exists()
+    assert pc.status([compute_csd_peaks])["compute_csd_peaks"] == 1
 
     # Second call loads from cache — peaks_from_model is not re-invoked
     mock_peaks_from_model.reset_mock()
@@ -534,10 +671,11 @@ def test_denoise_with_caching(dwi4: Dwi, tmp_path: Path) -> None:
     assert isinstance(denoised, Dwi)
     assert denoised.volume.get_array().shape == dwi4.volume.get_array().shape
     assert np.allclose(denoised.volume.get_affine(), dwi4.volume.get_affine())
-    assert (tmp_path / "denoise.nii.gz").exists()
-    assert (tmp_path / "denoise.bval").exists()
-    assert (tmp_path / "denoise.bvec").exists()
-    assert pc.status([Dwi.denoise])["Dwi.denoise"] is True
+    entry_dir = _only_cache_entry(tmp_path, "denoise")
+    assert (entry_dir / "denoise.nii.gz").exists()
+    assert (entry_dir / "denoise.bval").exists()
+    assert (entry_dir / "denoise.bvec").exists()
+    assert pc.status([Dwi.denoise])["Dwi.denoise"] == 1
 
     # Second call returns the same volume loaded from cache
     with pc:
@@ -555,7 +693,9 @@ def test_params_json_has_scalars_and_hashes(dwi3: Dwi, tmp_path: Path) -> None:
     with Cache(tmp_path):
         dwi3.estimate_dti()
 
-    params = json.loads((tmp_path / "estimate_dti.params.json").read_text())
+    entry_dir = _only_cache_entry(tmp_path, "estimate_dti")
+    params = json.loads((entry_dir / "estimate_dti.params.json").read_text())
+    assert params["version"] == 1
     # Scalar arguments (mask=None) are human-readable in the "scalars" section.
     assert "scalars" in params
     assert params["scalars"]["mask"] is None
@@ -581,6 +721,7 @@ def test_data_change_triggers_recompute(dwi3: Dwi, tmp_path: Path, mocker) -> No
         dwi3.estimate_dti()
 
     save_spy.assert_called_once()  # recomputed because the data hash changed
+    assert pc.status([Dti.estimate_dti])["Dti.estimate_dti"] == 2
 
 
 def test_untracked_param_warns(tmp_path: Path) -> None:

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from dataclasses import dataclass
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -26,6 +27,24 @@ from kwneuro.resource import (
     InMemoryResponseFunctionResource,
     InMemoryVolumeResource,
 )
+
+
+@dataclass
+class _CacheableText:
+    """Minimal result type for exercising bare @cacheable behavior."""
+
+    value: str
+
+    @classmethod
+    def _cache_files(cls, step_name: str) -> list[str]:
+        return [f"{step_name}.txt"]
+
+    def _cache_save(self, cache_dir: Path, step_name: str) -> None:
+        (cache_dir / f"{step_name}.txt").write_text(self.value)
+
+    @classmethod
+    def _cache_load(cls, cache_dir: Path, step_name: str) -> _CacheableText:
+        return cls((cache_dir / f"{step_name}.txt").read_text())
 
 
 @pytest.fixture
@@ -248,6 +267,54 @@ def test_cacheable_no_op_outside_context(dwi3: Dwi) -> None:
     """@cacheable is a transparent pass-through when no Cache context is active."""
     dti = dwi3.estimate_dti()
     assert isinstance(dti, Dti)
+
+
+def test_cacheable_reuses_all_argument_variants(tmp_path: Path) -> None:
+    """Results for multiple inputs remain cached across Cache contexts."""
+    calls: list[int] = []
+
+    @cacheable  # type: ignore[untyped-decorator]
+    def fn(value: int) -> _CacheableText:
+        calls.append(value)
+        return _CacheableText(str(value))
+
+    with Cache(tmp_path):
+        assert fn(1).value == "1"
+        assert fn(2).value == "2"
+
+    with Cache(tmp_path):
+        assert fn(1).value == "1"
+        assert fn(2).value == "2"
+
+    assert calls == [1, 2]
+
+
+def test_cacheable_reuses_earlier_argument_variant_with_cache_spec(
+    tmp_path: Path,
+) -> None:
+    """Calling A after caching A and B reuses A's cached result."""
+    calls: list[int] = []
+
+    def _save(result: str, cache_dir: Path) -> None:
+        (cache_dir / "out.txt").write_text(result)
+
+    @cacheable(  # type: ignore[untyped-decorator]
+        CacheSpec(
+            files=["out.txt"],
+            save=_save,
+            load=lambda cache_dir: (cache_dir / "out.txt").read_text(),
+        )
+    )
+    def fn(value: int) -> str:
+        calls.append(value)
+        return str(value)
+
+    with Cache(tmp_path):
+        assert fn(1) == "1"  # A: miss
+        assert fn(2) == "2"  # B: miss
+        assert fn(1) == "1"  # A: hit
+
+    assert calls == [1, 2]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_reg.py
+++ b/tests/test_reg.py
@@ -25,6 +25,14 @@ from kwneuro.resource import (
 from kwneuro.structural import StructuralImage
 
 
+def _single_cache_entry(cache_root: Path, step_name: str) -> Path:
+    entries = list((cache_root / step_name).iterdir())
+    assert len(entries) == 1
+    entry = entries[0]
+    assert entry.is_dir()
+    return entry
+
+
 @pytest.fixture
 def structural() -> StructuralImage:
     return StructuralImage(volume=InMemoryVolumeResource(array=np.zeros((2, 2, 2))))
@@ -269,10 +277,11 @@ def test_register_dwi_to_structural_caches_transform_files(
     with cache:
         first = register_dwi_to_structural(dwi=dwi1, structural=structural)
 
-    cache_dir = tmp_path / "register_dwi_to_structural_transform"
+    cache_entry = _single_cache_entry(tmp_path, "register_dwi_to_structural")
+    transform_dir = cache_entry / "register_dwi_to_structural_transform"
     assert mock_reg.call_count == 1
-    assert cache.status([register_dwi_to_structural])["register_dwi_to_structural"]
-    assert json.loads((cache_dir / "transform.json").read_text()) == {
+    assert cache.status([register_dwi_to_structural])["register_dwi_to_structural"] == 1
+    assert json.loads((transform_dir / "transform.json").read_text()) == {
         "fwd": ["1Warp.nii.gz", "0GenericAffine.mat"],
         "inv": ["0GenericAffine.mat"],
     }
@@ -283,7 +292,7 @@ def test_register_dwi_to_structural_caches_transform_files(
     assert [Path(p).name for p in first._ants_inv_paths] == ["0GenericAffine.mat"]
     for path in first._ants_fwd_paths + first._ants_inv_paths:
         assert Path(path).exists()
-        assert Path(path).parent == cache_dir
+        assert Path(path).parent == transform_dir
 
     mock_reg.reset_mock()
     with cache:

--- a/tests/test_structural.py
+++ b/tests/test_structural.py
@@ -61,6 +61,14 @@ def mock_ants_vol(structural: StructuralImage):
     )
 
 
+def _single_cache_entry(cache_root: Path, step_name: str) -> Path:
+    entries = list((cache_root / step_name).iterdir())
+    assert len(entries) == 1
+    entry = entries[0]
+    assert entry.is_dir()
+    return entry
+
+
 # ---------------------------------------------------------------------------
 # Save / load
 # ---------------------------------------------------------------------------
@@ -142,7 +150,8 @@ def test_correct_bias_caching(
     with Cache(tmp_path):
         structural.correct_bias()
     assert mock_n4.call_count == 1
-    assert (tmp_path / "correct_bias.nii.gz").exists()
+    cache_entry = _single_cache_entry(tmp_path, "correct_bias")
+    assert (cache_entry / "correct_bias.nii.gz").exists()
 
     mock_n4.reset_mock()
     with Cache(tmp_path):
@@ -276,7 +285,8 @@ def test_segment_tissues_caching(
     with Cache(tmp_path):
         structural.segment_tissues(method="atropos")
     assert mock_atropos.call_count == 1
-    assert (tmp_path / "segment_tissues.nii.gz").exists()
+    cache_entry = _single_cache_entry(tmp_path, "segment_tissues")
+    assert (cache_entry / "segment_tissues.nii.gz").exists()
 
     mock_atropos.reset_mock()
     with Cache(tmp_path):
@@ -307,7 +317,8 @@ def test_segment_tissues_caching_writes_method_param(
     with Cache(tmp_path):
         structural.segment_tissues(method="atropos")
 
-    params = json.loads((tmp_path / "segment_tissues.params.json").read_text())
+    cache_entry = _single_cache_entry(tmp_path, "segment_tissues")
+    params = json.loads((cache_entry / "segment_tissues.params.json").read_text())
     assert params["scalars"]["method"] == "atropos"
 
 
@@ -371,7 +382,8 @@ def test_parcellate_caching(
     with Cache(tmp_path):
         structural.parcellate(method="dkt")
     assert mock_antspynet.desikan_killiany_tourville_labeling.call_count == 1
-    assert (tmp_path / "parcellate.nii.gz").exists()
+    cache_entry = _single_cache_entry(tmp_path, "parcellate")
+    assert (cache_entry / "parcellate.nii.gz").exists()
 
     mock_antspynet.desikan_killiany_tourville_labeling.reset_mock()
     mocker.patch.dict(sys.modules, {"antspynet": mock_antspynet})

--- a/tests/test_tractseg.py
+++ b/tests/test_tractseg.py
@@ -4,6 +4,7 @@ import numpy as np
 import pytest
 import scipy.linalg
 
+from kwneuro.cache import Cache
 from kwneuro.dwi import Dwi
 from kwneuro.resource import (
     InMemoryBvalResource,
@@ -100,3 +101,66 @@ def test_tractseg(
     mocker_run_tract_seg.assert_called_once()
 
     assert np.allclose(seg_volume.get_array(), mock_tractseg_output)
+
+
+def test_tractseg_caches_multiple_argument_variants(
+    mocker,
+    tmp_path,
+    dwi_data_small_random,
+):
+    """Different TractSeg output types retain separate reusable results."""
+    vol = dwi_data_small_random.volume
+    vol_shape = vol.get_array().shape[:-1]
+    affine = vol.get_affine()
+    mask = InMemoryVolumeResource(array=np.ones(vol_shape), affine=affine)
+
+    peaks = (
+        InMemoryVolumeResource(array=np.ones((*vol_shape, 3, 3)), affine=affine),
+        InMemoryVolumeResource(array=np.ones((*vol_shape, 3)), affine=affine),
+    )
+    tractseg_outputs = {
+        "tract_segmentation": np.full((*vol_shape, 72), 1.0),
+        "TOM": np.full((*vol_shape, 60), 2.0),
+    }
+
+    def run_tractseg(*, data, output_type):
+        assert data.shape == (*vol_shape, 9)
+        return tractseg_outputs[output_type]
+
+    mock_run_tractseg = mocker.patch(
+        "kwneuro.tractseg._call_tractseg", side_effect=run_tractseg
+    )
+
+    with Cache(tmp_path):
+        result_a = extract_tractseg(
+            dwi_data_small_random,
+            mask,
+            output_type="tract_segmentation",
+            csd_peaks=peaks,
+        )
+        result_b = extract_tractseg(
+            dwi_data_small_random,
+            mask,
+            output_type="TOM",
+            csd_peaks=peaks,
+        )
+
+    with Cache(tmp_path):
+        cached_a = extract_tractseg(
+            dwi_data_small_random,
+            mask,
+            output_type="tract_segmentation",
+            csd_peaks=peaks,
+        )
+        cached_b = extract_tractseg(
+            dwi_data_small_random,
+            mask,
+            output_type="TOM",
+            csd_peaks=peaks,
+        )
+
+    assert mock_run_tractseg.call_count == 2
+    assert np.allclose(result_a.get_array(), tractseg_outputs["tract_segmentation"])
+    assert np.allclose(result_b.get_array(), tractseg_outputs["TOM"])
+    assert np.allclose(cached_a.get_array(), tractseg_outputs["tract_segmentation"])
+    assert np.allclose(cached_b.get_array(), tractseg_outputs["TOM"])


### PR DESCRIPTION
Organize cache results by a hash that is computed from all the arguments, addressing #160 